### PR TITLE
Fix #6

### DIFF
--- a/blog/archive.html
+++ b/blog/archive.html
@@ -12,7 +12,7 @@ permalink: "/blog/archive/"
       <dd class="accordion-navigation">
       <a href="#panel{{ forloop.index }}"><span class="iconfont"></span> {% if post.subheadline %}{{ post.subheadline }} › {% endif %}<strong>{{ post.title }}</strong></a>
         <div id="panel{{ forloop.index }}" class="content">
-          {% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %}
+          {% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% elsif post.teaser %}{{ post.teaser | strip_html | escape }}{% elsif post.excerpt %}{{ post.excerpt | strip_html | escape }}{% endif %}
           <a href="{{ site.url }}{{ post.url }}" title="Read {{ post.title escape_once }}"><strong>{{ site.data.language.read_more }}</strong></a><br><br>
         </div>
       </dd>


### PR DESCRIPTION
I'm using the `post.excerpt` function of Jekyll, but we can replace to something like:

`{{ post.content | strip_html | truncatewords: 50 }}`
