### PR TITLE
Enabling comments.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -115,7 +115,7 @@ defaults:
     values:
       show_meta: false		# Hide metadata for all pages
       # sidebar:    		# Possible values › left, right › by default there will be no sidebar
-      comments: false
+      comments: true
       author: gvwilson		# Default author for pages
   -
     scope:
@@ -124,7 +124,7 @@ defaults:
     values:
       show_meta: true		# Show metadata for all posts
       # sidebar:		# Possible values › left, right › by default there will be no sidebar
-      comments: false
+      comments: true
       author: gvwilson		# Default author for posts
 
 #       _   __            _             __  _


### PR DESCRIPTION
This will fix #40, but doesn't work yet: settings 'comments' to 'true' in _config.yml makes comments show up on blog posts, but not on pages.

@SamuelMoraesF please review.
