### PR TITLE
Fixes #34: Show workshops by end date.

### DIFF
--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -63,7 +63,8 @@ def split_workshops(workshops, today):
     past = []
     current = []
     for w in workshops:
-        if w['start'] < today:
+        sort_date = w['end'] if w['end'] else w['start']
+        if sort_date < today:
             past.append(w)
         else:
             current.append(w)


### PR DESCRIPTION
Workshops that are currently running will now be shown in the workshops page. Need to run `make amy` for the changes to take effect.

Note: The events/published.yaml list contained workshops with no end dates. Those will be placed into the according list (past or current) by their start date instead.
