### PR TITLE
Fix for #3: removes trailing comma from geo json.

### DIFF
--- a/pages/workshops.json
+++ b/pages/workshops.json
@@ -2,12 +2,15 @@
 layout: null
 permalink: /workshops.json
 ---
+{% assign first = true %}
 {
   "type": "FeatureCollection",
   "features": [
   {% for workshop in site.data.amy.workshops_current %}
     {% unless workshop.longitude == NULL or workshop.latitude == NULL %}
-      {% unless forloop.first %},{% endunless %}
+      {% if first == true %}
+        {% assign first = false %}
+      {% else %},{% endif %}
       {
         "type": "Feature",
         "geometry": {

--- a/pages/workshops.json
+++ b/pages/workshops.json
@@ -7,16 +7,19 @@ permalink: /workshops.json
   "features": [
   {% for workshop in site.data.amy.workshops_current %}
     {% unless workshop.longitude == NULL or workshop.latitude == NULL %}
-    {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates":[{{workshop.longitude}},{{workshop.latitude}}]
-      },
-      "properties": {
-        "marker-color": "#2b3990",
-        "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+      {% unless forloop.first %},{% endunless %}
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Point",
+          "coordinates":[{{workshop.longitude}},{{workshop.latitude}}]
+        },
+        "properties": {
+          "marker-color": "#2b3990",
+          "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+        }
       }
-    }{% unless forloop.last %},{% endunless %}{% endunless %}{% endfor %}
+    {% endunless %}
+  {% endfor %}
   ]
 }

--- a/pages/workshops_past.json
+++ b/pages/workshops_past.json
@@ -7,16 +7,19 @@ permalink: /workshops_past.json
   "features": [
   {% for workshop in site.data.amy.workshops_past %}
     {% unless workshop.longitude == NULL or workshop.latitude == NULL %}
-    {
-      "type": "Feature",
-      "geometry": {
-        "type": "Point",
-        "coordinates":[{{workshop.longitude}},{{workshop.latitude}}]
-      },
-      "properties": {
-        "marker-color": "#2b3990",
-        "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+      {% unless forloop.first %},{% endunless %}
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Point",
+          "coordinates":[{{workshop.longitude}},{{workshop.latitude}}]
+        },
+        "properties": {
+          "marker-color": "#2b3990",
+          "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+        }
       }
-    }{% unless forloop.last %},{% endunless %}{% endunless %}{% endfor %}
+    {% endunless %}
+  {% endfor %}
   ]
 }

--- a/pages/workshops_past.json
+++ b/pages/workshops_past.json
@@ -2,12 +2,15 @@
 layout: null
 permalink: /workshops_past.json
 ---
+{% assign first = true %}
 {
   "type": "FeatureCollection",
   "features": [
   {% for workshop in site.data.amy.workshops_past %}
     {% unless workshop.longitude == NULL or workshop.latitude == NULL %}
-      {% unless forloop.first %},{% endunless %}
+      {% if first == true %}
+        {% assign first = false %}
+      {% else %},{% endif %}
       {
         "type": "Feature",
         "geometry": {


### PR DESCRIPTION
Fixes the trailing comma placed into the generated geo json file when a workshop is missing geo-coordinates.
