### PR TITLE
Add .jekyll-metadata to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 *~
 .DS_Store
+.jekyll-metadata


### PR DESCRIPTION
`.jekyll-metadata` is a temporary file used for incremental generation, it should be ignored.
