### PR TITLE
Make the navigation bar disappear sooner

### DIFF
--- a/_sass/_03_settings_mixins_media_queries.scss
+++ b/_sass/_03_settings_mixins_media_queries.scss
@@ -250,8 +250,8 @@ $column-gutter: rem-calc(30) !default;
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
 $small-range: (0em, 40em);
-$medium-range: (40.063em, 64em);
-$large-range: (64.063em, 90em);
+$medium-range: (40.063em, 67em);
+$large-range: (67.063em, 90em);
 $xlarge-range: (90.063em, 120em);
 $xxlarge-range: (120.063em, 99999999em);
 


### PR DESCRIPTION
Due to the large number of elements in the menu, the left and right navbars
clash before the mobile layout kicks in. This change makes the switch happen
at 67em rather than 63.

Be aware that all screens smaller than 1072px will now see the mobile navigation. I would prefer a leaner menu bar, with fewer element (better UX in general I think).

Perhaps by merging "About" and "Foundation"? The whole "Contact" page can be in the footer I guess, or linked under "Join us".
