### PR TITLE
Fixing #112 by using protocol-independent paths for loading CSS files.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,8 @@ description: "Software Carpentry is volunteer non-profit organization dedicated 
 # See > authors.yml
 author: gvwilson
 
-# This URL identifies the domain.
-url: 'http://software-carpentry.org'
+# This URL identifies the domain.  It uses a protocol-independent path so that things will load with both HTTP and HTTPS.
+url: '//software-carpentry.org'
 
 # This URL is the root of the site below the domain.
 baseurl: ''

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -5,8 +5,7 @@
 #
 # Start development with › $ jekyll serve --config _config.yml,_config_dev.yml
 
-url: 'http://localhost:4000'
-filesurl: '/files'
+url: '//localhost:4000'
 
 sass:
   # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style


### PR DESCRIPTION
1.  Modify `url` variable in `_config.yml` to use `//software-carpentry.org` instead of specifying protocol.
2.  Remove `filesurl` variable from `_config_dev.yml` (redundant with variable of same name in `_config.yml`).
