### PR TITLE
bin/get-amy.py: proper argparsing, args for tag filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ commands :
 
 ## amy        : update workshop and other data from AMY.
 amy :
-	${PY} bin/get-amy.py https://amy.software-carpentry.org/api/v1/ _data/amy.yml
+	${PY} bin/get-amy.py -u https://amy.software-carpentry.org/api/v1/ -o _data/amy.yml -t SWC -t DC
 
 ## dashboard  : update data about status of projects - requires ~/.git-token.
 dashboard :

--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -65,8 +65,8 @@ def fetch_info(base_url, url, tags=None):
 
     # Consider filtering by tags.
     if tags:
-        query_params = [urllib.parse.urlencode({'tag': tag}) for tag in tags]
-        query = '&'.join(query_params)
+        query_params = [('tag', tag) for tag in tags]
+        query = urllib.parse.urlencode(query_params)
         address = '{address}?{query}'.format(address=address, query=query)
 
     which_python = sys.version_info[:3]

--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -2,22 +2,19 @@
 
 '''Fetch info about workshops, airports, etc. from AMY.'''
 
+import argparse
 import sys
 import time
 import datetime
 import ssl
 import urllib.request
+import urllib.parse
 import yaml
 
-def main():
+def main(amy_url, output_file, tags):
     '''
     Fetch information and store in one YAML file.
     '''
-
-    # Controls.
-    amy_url = sys.argv[1]
-    output_file = sys.argv[2]
-
     # Get stock information from AMY.
     config = {
         'timestamp' : time.strftime('%Y%m%dT%H%M%SZ', time.gmtime()),
@@ -27,8 +24,8 @@ def main():
 
     # Adjust.
     config['workshops_past'], config['workshops_current'] = \
-        split_workshops(fetch_info(amy_url, 'events/published.yaml'), \
-                                   datetime.date.today())
+        split_workshops(fetch_info(amy_url, 'events/published.yaml', tags=tags),
+                        datetime.date.today())
     config['workshops'] = [config['workshops_past'], config['workshops_current']]
 
     # Coalesce flag information.
@@ -38,14 +35,24 @@ def main():
     }
 
     # Save.
-    with open(output_file, 'w') as writer:
-        yaml.dump(config, writer, encoding='utf-8', allow_unicode=True)
+    try:
+        with open(output_file, 'w') as writer:
+            yaml.dump(config, writer, encoding='utf-8', allow_unicode=True)
+    except TypeError:
+        # Output_file isn't a string, so it's a file.
+        yaml.dump(config, output_file, encoding='utf-8', allow_unicode=True)
 
 
-def fetch_info(base_url, url):
+def fetch_info(base_url, url, tags=None):
     '''Download and save data.'''
 
     address = base_url + url
+
+    # Consider filtering by tags.
+    if tags:
+        query_params = [urllib.parse.urlencode({'tag': tag}) for tag in tags]
+        query = '&'.join(query_params)
+        address = '{address}?{query}'.format(address=address, query=query)
 
     which_python = sys.version_info[:3]
     if which_python <= (3, 4, 2):
@@ -82,4 +89,17 @@ def sort_flags(data):
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description=sys.modules[__name__].__doc__)
+    parser.add_argument('-u', '--api-url', type=str, required=True,
+                        help='Base URL of AMY API used for gathering information.')
+    parser.add_argument('-o', '--output', default=sys.stdout,
+                        help='Output file.  By default: stdout.')
+    parser.add_argument('-t', '--tag', action='append', choices=['SWC', 'DC'],
+                        help='Filter events by this tag.  '
+                             'You can use it multiple times.')
+
+    args = vars(parser.parse_args())
+    amy_url = args['api_url']
+    output_file = args['output']
+    tags = args['tag']
+    main(amy_url, output_file, tags)

--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -50,11 +50,11 @@ def main(amy_url, output_file, tags):
     }
 
     # Save.
-    try:
+    if isinstance(output_file, str):
         with open(output_file, 'w') as writer:
             yaml.dump(config, writer, encoding='utf-8', allow_unicode=True)
-    except TypeError:
-        # Output_file isn't a string, so it's a file.
+    else:
+        # We assume `output_file` is a file-like object.
         yaml.dump(config, output_file, encoding='utf-8', allow_unicode=True)
 
 

--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -11,6 +11,21 @@ import urllib.request
 import urllib.parse
 import yaml
 
+
+def handle_args():
+    parser = argparse.ArgumentParser(description=sys.modules[__name__].__doc__)
+    parser.add_argument('-u', '--api-url', type=str, required=True,
+                        help='Base URL of AMY API used for gathering information.')
+    parser.add_argument('-o', '--output', default=sys.stdout,
+                        help='Output file.  By default: stdout.')
+    parser.add_argument('-t', '--tag', action='append', choices=['SWC', 'DC'],
+                        help='Filter events by this tag.  '
+                             'You can use it multiple times.')
+
+    args = vars(parser.parse_args())
+    return args
+
+
 def main(amy_url, output_file, tags):
     '''
     Fetch information and store in one YAML file.
@@ -89,17 +104,6 @@ def sort_flags(data):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description=sys.modules[__name__].__doc__)
-    parser.add_argument('-u', '--api-url', type=str, required=True,
-                        help='Base URL of AMY API used for gathering information.')
-    parser.add_argument('-o', '--output', default=sys.stdout,
-                        help='Output file.  By default: stdout.')
-    parser.add_argument('-t', '--tag', action='append', choices=['SWC', 'DC'],
-                        help='Filter events by this tag.  '
-                             'You can use it multiple times.')
+    args = handle_args()
+    main(amy_url=args['api_url'], output_file=args['output'], tags=args['tag'])
 
-    args = vars(parser.parse_args())
-    amy_url = args['api_url']
-    output_file = args['output']
-    tags = args['tag']
-    main(amy_url, output_file, tags)


### PR DESCRIPTION
1. Add proper solution for argument parsing (argparse module from
   Python).
2. Add '-t'/'--tag' arguments for specifying tags used in event
   filtering.
3. Filter events (via query) by tags provided.
