### PR TITLE
Get icons for training in the right order

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -122,8 +122,8 @@ redirect_from:
   </tr>
   <tr id="training">
     <td>Instructor Training</td>
-    <td><a href="{{site.github_io_url}}/instructor-training" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.github_url}}/instructor-training" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+    <td><a href="{{site.github_io_url}}/instructor-training" target="_blank" class="icon-browser" title="icon-browser"></a></td>
+    <td><a href="{{site.github_url}}/instructor-training" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/instructor-training/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#wilson.g">Greg Wilson</a>


### PR DESCRIPTION
The site displays a github octocat icon for the training github-io site and a browser icon for the github repository. Switch these around so that the links and the icons agree.
