### PR TITLE
Create 2016-01-12-instructor-debriefing-round-01.html

### DIFF
--- a/_posts/2016/01/2016-01-12-instructor-debriefing-round-01.html
+++ b/_posts/2016/01/2016-01-12-instructor-debriefing-round-01.html
@@ -9,7 +9,7 @@ category: ["Debriefing"]
 ---
 <!-- start excerpt -->
 <p>
-On January 11, 2016 we ran the 1st round of post-workshop instructor debriefing of the calendar year! The mentoring committee ran 22 debriefing session in 2015, and we are exciting about continuing to host and improve these session this year. 
+On January 11, 2016 we ran the 1st round of post-workshop instructor debriefing of the calendar year! The mentoring committee ran 22 debriefing session in 2015, and we are exciting about continuing to host and improve these sessions this year. 
 
 Interestingly, all instructors present participated in 3-day format Software Carpentry workshops. Read on to find out more about the changes made, what worked well, and what didn't. 
 </p>
@@ -17,14 +17,14 @@ Interestingly, all instructors present participated in 3-day format Software Car
 <h2>Worked well</h2>
 Both of these Nordic workshops were spearheaded by newly minted instructors. Greg Wilson had approached them in the past about becoming instructors and hosting workshops, and this effort has come to fruition. Both workshops were well attended and received, and everyone is looking forward to continuing learning, coding, and networking. 
 
-The stockholm group created an exercise/challenge that combined testing and pull requests. Students were given a broken python function; after fixing the errors, the student's submitted their changes via pull requests. View the exercise [here](https://github.com/bast/python-tdd-exercises).
+The Stockholm group created an exercise/challenge that combined testing and pull requests. Students were given a broken python function; after fixing the errors, the student's submitted their changes via pull requests. View the exercise [here](https://github.com/bast/python-tdd-exercises).
 
-The Heliski group incorporated afternoon work sessions where the students could apply the newly-learned tools to their own data or get more help of the morning's topics. 
+The Helsinki group incorporated afternoon work sessions where the students could apply the newly-learned tools to their own data or get more help of the morning's topics. 
 
 <h2>What could have gone better</h2>
-The Heliski group gave a lecture using the Software Carpentry [Best Practices in Scientific Computing slideshow](http://swcarpentry.github.io/slideshows/best-practices/index.html). The material is excellent, but the lecture style delivery was a stark constrast to the hands-on style of teaching the day before. 
+The Helsinki group gave a lecture using the Software Carpentry [Best Practices in Scientific Computing slideshow](http://swcarpentry.github.io/slideshows/best-practices/index.html). The material is excellent, but the lecture style delivery was a stark constrast to the hands-on style of teaching the day before. 
 
-We wonder if there isn't a way to add the "rules" to various lesson where appropriate. This way, instructors can weave these best practices into the workshop, without needed a separate block of time to cover the. Thoughts? 
+We wonder if there isn't a way to add the "rules" to various lesson where appropriate. This way, instructors can weave these best practices into the workshop, without needing a separate block of time to cover the slides independently. Thoughts? 
 
 <h2>Other comments</h2>
 Roman Valls Guimera, an instructor with the SciLifeLab, wrote about about their workshop. You can read it and look at some great photos [here](http://blogs.nopcode.org/brainstorm/2015/12/02/software-and-data-carpentry-workshop-2015/)

--- a/_posts/2016/01/2016-01-12-instructor-debriefing-round-01.html
+++ b/_posts/2016/01/2016-01-12-instructor-debriefing-round-01.html
@@ -1,0 +1,40 @@
+---
+layout: blog
+root: ../../..
+author: "Rayna Harris and Kate Hertweck"
+title: "2016 Post-Workshop Instructor Debriefing, Round 01"
+date: 2016-01-12
+time: "10:00:00"
+category: ["Debriefing"]
+---
+<!-- start excerpt -->
+<p>
+On January 11, 2016 we ran the 1st round of post-workshop instructor debriefing of the calendar year! The mentoring committee ran 22 debriefing session in 2015, and we are exciting about continuing to host and improve these session this year. 
+
+Interestingly, all instructors present participated in 3-day format Software Carpentry workshops. Read on to find out more about the changes made, what worked well, and what didn't. 
+</p>
+<!-- end excerpt -->
+<h2>Worked well</h2>
+Both of these Nordic workshops were spearheaded by newly minted instructors. Greg Wilson had approached them in the past about becoming instructors and hosting workshops, and this effort has come to fruition. Both workshops were well attended and received, and everyone is looking forward to continuing learning, coding, and networking. 
+
+The stockholm group created an exercise/challenge that combined testing and pull requests. Students were given a broken python function; after fixing the errors, the student's submitted their changes via pull requests. View the exercise [here](https://github.com/bast/python-tdd-exercises).
+
+The Heliski group incorporated afternoon work sessions where the students could apply the newly-learned tools to their own data or get more help of the morning's topics. 
+
+<h2>What could have gone better</h2>
+The Heliski group gave a lecture using the Software Carpentry [Best Practices in Scientific Computing slideshow](http://swcarpentry.github.io/slideshows/best-practices/index.html). The material is excellent, but the lecture style delivery was a stark constrast to the hands-on style of teaching the day before. 
+
+We wonder if there isn't a way to add the "rules" to various lesson where appropriate. This way, instructors can weave these best practices into the workshop, without needed a separate block of time to cover the. Thoughts? 
+
+<h2>Other comments</h2>
+Roman Valls Guimera, an instructor with the SciLifeLab, wrote about about their workshop. You can read it and look at some great photos [here](http://blogs.nopcode.org/brainstorm/2015/12/02/software-and-data-carpentry-workshop-2015/)
+
+<h2>Thanks</h2>
+<p>
+We are grateful to the instructors who attended debriefing sessions this round:
+</p>
+<ul>
+  <li>Radovan Bast, [SciLifeLab Stockholm](https://pythonkurs.github.io/2015-11-30-swc_data/)</li>
+  <li>Olav Vahtras, [SciLifeLab Stockholm](https://pythonkurs.github.io/2015-11-30-swc_data/)</li>
+  <li>Joona Lehtomäki, [University of Helsinki](https://cbig.github.io/2015-11-25-helsinki/)</li>
+</ul>


### PR DESCRIPTION
Here is a brief write up of this morning's debriefing. I'd like to give @k8hertweck a chance to add/make changes as necessary (is the best practices slide show the link you found as well or is there something else?). 

Also, I used the template made by @rgaiacs, but modified it by deleted the section on installation issues (not discusses), changed the "what went wrong" to "what could have gone better", and added an "other comments" section because I wasn't sure where the link to the workshop blog should go.
