### PR TITLE
Fix ordering of workshops

### DIFF
--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -70,6 +70,9 @@ def main(amy_url, output_file, tags, all_=True):
         del slugs
         del workshops
 
+    # Always sort workshops by the ascending start date.
+    unique_workshops = sorted(unique_workshops, key=lambda w: w['start'])
+
     # Adjust.
     config['workshops_past'], config['workshops_current'] = \
         split_workshops(unique_workshops, datetime.date.today())

--- a/bin/get-amy.py
+++ b/bin/get-amy.py
@@ -71,7 +71,8 @@ def main(amy_url, output_file, tags, all_=True):
         del workshops
 
     # Always sort workshops by the ascending start date.
-    unique_workshops = sorted(unique_workshops, key=lambda w: w['start'])
+    unique_workshops = sorted(unique_workshops,
+                              key=lambda w: (w['start'], w['slug']))
 
     # Adjust.
     config['workshops_past'], config['workshops_current'] = \

--- a/pages/index.html
+++ b/pages/index.html
@@ -71,7 +71,7 @@ permalink: /index.html
   <div class="medium-4 columns">
     <h3>Upcoming Workshops</h3>
     <table class="table table-striped workshops">
-      {% for w in site.data.amy.workshops_current reversed %}
+      {% for w in site.data.amy.workshops_current %}
       <tr>
 	<td>
 	  <img src="{{site.filesurl}}/flags/{{site.flag_size}}/{{w.country | downcase}}.png" title="{{w.country | replace: '-', ' '}}" alt="{{w.country | replace: '-', ' ' | downcase}}" />

--- a/pages/workshops.html
+++ b/pages/workshops.html
@@ -67,7 +67,7 @@ redirect_from:
 <div id="future">
   <h2>Future Workshops</h2>
   <table class="table table-striped workshops">
-    {% for w in site.data.amy.workshops_current reversed %}
+    {% for w in site.data.amy.workshops_current %}
     <tr>
       <td><img src="{{site.filesurl}}/flags/{{site.flag_size}}/{{w.country | downcase}}.png" title="{{w.country | replace: '-', ' ' | downcase}}" alt="{{w.country | replace: '-', ' ' | downcase}}" /></td>
       <td class="link"><a href="{{w.url}}">{{w.venue}}</a></td>

--- a/pages/workshops_past.html
+++ b/pages/workshops_past.html
@@ -22,7 +22,7 @@ redirect_from:
 </div>
 
 <table class="table table-striped workshops">
-  {% for w in site.data.amy.workshops_past %}
+  {% for w in site.data.amy.workshops_past reversed %}
   <tr>
     <td><img src="{{site.filesurl}}/flags/{{site.flag_size}}/{{w.country}}.png" title="{{w.country | replace: '-', ' '}}" alt="{{w.country | replace: '-', ' '}}" /></td>
     <td class="link"><a href="{{w.url}}">{{w.venue}}</a></td>


### PR DESCRIPTION
Workshops saved from AMY are always sorted by start date in ascending
order (oldest first).

The templates expected different format (usually newest first), so
they were flipped.
