### PR TITLE
Improving layout of announcement about candidates

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -3,14 +3,12 @@ layout: page-fullwidth
 permalink: /index.html
 ---
 <div class="row">
-  <div class="medium-2 columns">
-  </div>
-  <div class="medium-8 columns">
-    <h4>2016 Elections</h2>
+  <div class="medium-12 columns" align="center">
+    <h3>2016 Elections</h3>
     <p>
       <strong>
 	The election for the 2016 Steering Committee will take place in the week of February 15-19, 2016.
-	The fourteen people below have put themselves forward as candidates,
+	The people below have put themselves forward as candidates,
 	and we will announce online discussion sessions in which you can meet them and ask them questions soon.
       </strong>
     </p>
@@ -35,8 +33,7 @@ permalink: /index.html
       </tr>
     </table>
   </div>
-  <div class="medium-2 columns">
-  </div>
+  <br/>
 </div>
 
 <div class="row">

--- a/pages/index.html
+++ b/pages/index.html
@@ -9,7 +9,8 @@ permalink: /index.html
       <strong>
 	The election for the 2016 Steering Committee will take place in the week of February 15-19, 2016.
 	The people below have put themselves forward as candidates,
-	and we will announce online discussion sessions in which you can meet them and ask them questions soon.
+	and will take part in question and answer sessions on February 9, 2016
+	to talk to the community about their candidacy and how they hope to contribute to the future of Software Carpentry.
       </strong>
     </p>
     <table>


### PR DESCRIPTION
Some of this formatting got lost somewhere, leaving us with an awkward left-aligned blob of text.

FIXME: still needs date(s) and time(s) for Q&A sessions with candidates.
