### PR TITLE
Update elsewhere-on-the-web.md: fix wrong link syntax

### DIFF
--- a/_posts/2016/01/2016-01-29-elsewhere-on-the-web.md
+++ b/_posts/2016/01/2016-01-29-elsewhere-on-the-web.md
@@ -35,5 +35,5 @@ please note that several of them are being streamed on YouTube:
     taught by Bruno Grande (SFU) on June 13, 2016
 
 If you are teaching something out in the open that our audience might be interested in,
-please [send us a link](mailto:{{site.contact}}---we'd enjoy hearing more about it,
+please [send us a link](mailto:{{site.contact}})---we'd enjoy hearing more about it,
 and we're sure our readers would too.


### PR DESCRIPTION
The link to contact was not rendering properly because of missing `)`.
