### PR TITLE
Link to job advert doesn't work

### DIFF
--- a/_posts/2016/02/2016-02-01-ssi-job.md
+++ b/_posts/2016/02/2016-02-01-ssi-job.md
@@ -16,6 +16,6 @@ the UK. They are looking for an enthusiastic individual with a track record in
 a great social media presence and successfully promote events. 
 
 For more details and to apply, please see the [advert on the University of Edinburgh 
-website (job reference 035330)](https://www.vacancies.ed.ac.uk/pls/corehrrecruit/erq_jobspec_version_4.display_form). 
+website](https://www.vacancies.ed.ac.uk/pls/corehrrecruit/erq_search_package.search_form?p_company=5&p_internal_external=E) (search for vacancy reference ID 035330). 
 
 Note that the closing date is Thursday 18th February 2016 at 5pm GMT.


### PR DESCRIPTION
Okay so the vacancies.ed.ac.uk doesn't work because it tracks user sessions. So you won't be able to access an advert if you don't try to search for it first…
