### PR TITLE
Update to Jekyll 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'jekyll-redirect-from'
+gem 'jekyll-paginate'

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@
 
 gems:
   - jekyll-redirect-from
+  - jekyll-paginate
 
 whitelist:
   - jekyll-redirect-from


### PR DESCRIPTION
Changes:
- added a pagination gem

Maybe worth adding (cc @gvwilson):
- `--incremental` to `jekyl serve` (see https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0#need-for-speed): first build of the site (`make serve`) took me 92s, second one 15s
- profiler - for testing (see link above)

Noticed changes:
- blog categories aren't lowercased anymore (ie. 'amy' became 'AMY')

All in all it seems like pretty easy migration; I'll upgrade the server's version once this is merged.

This fixes #211.
