### PR TITLE
Renaming and cleaning up blog post.

### DIFF
--- a/_posts/2016/02/2016-02-05-swc-as-a-university-course.html
+++ b/_posts/2016/02/2016-02-05-swc-as-a-university-course.html
@@ -1,33 +1,39 @@
 ---
 layout: post
 authors: ["Daniel Chen"]
-title: "SWDCRetreat2015 - Round-table discussion: Software Carpentry as a University Course Recap"
+title: "Software Carpentry as a University Course"
 date: 2016-02-05
 time: "17:00:00"
 category: ["Community", "Teaching", "SWDCRetreat"]
+redirect_from:
+  - /blog/2016/02/swdcretreat2015-university_course.html
 ---
-<!-- start excerpt -->
-The <a href='http://swcarpentry.github.io/instructor-retreat-2015/'> inaugural Software Carpentry + Data Carpentry Instructor & Helper Retreat</a> is over!
-It was a long day, packed with tutorials, demos, and discussions.
-<a href='https://twitter.com/chendaniely'>I (Daniel Chen)</a>
-led a round table discussion with
-<a href='https://twitter.com/TiffanyTimbers'>Tiffany Timbers</a> and
-<a href='https://twitter.com/JennyBryan'>Jenny Bryan</a>.
-You can <a href='https://plus.google.com/events/c41eaub933br0odpb385rcg9j00'>watch</a> the discussion and/or
-<a href='http://pad.software-carpentry.org/swc-instructor-retreat-2015-7PM-UTC'>read</a> the notes on etherpad.
+<p>
+  The <a href="{{site.github_io_url}}/instructor-retreat-2015/"> inaugural Software Carpentry and Data Carpentry Instructor and Helper Retreat</a> is over!
+  It was a long day, packed with tutorials, demos, and discussions.
+  <a href="https://twitter.com/chendaniely">I (Daniel Chen)</a>
+  led a round table discussion with
+  <a href="https://twitter.com/TiffanyTimbers">Tiffany Timbers</a> and
+  <a href="https://twitter.com/JennyBryan">Jenny Bryan</a>.
+  You can <a href="https://plus.google.com/events/c41eaub933br0odpb385rcg9j00">watch</a> the discussion and/or
+  <a href="http://pad.software-carpentry.org/swc-instructor-retreat-2015-7PM-UTC">read</a> the notes on etherpad.
+</p>
 
-<!-- end excerpt -->
+<!--more-->
 
-First, thanks to everyone who joined the discussion:
+<p>
+  First, thanks to everyone who joined the discussion:
+</p>
+
 <ul>
-  <li>Tiffany Timbers / <a href='www.twitter.com/tiffanytimers'>@TiffanyTimbers</a></li>
-  <li>Jenny Bryan / <a href='www.twitter.com/jennybryan>'>@JennyBryan</a></li>
-  <li>Daniel Chen / <a href='www.twitter.com/chendaniely'>@chendaniely</a></li>
+  <li>Tiffany Timbers / <a href="www.twitter.com/tiffanytimers">@TiffanyTimbers</a></li>
+  <li>Jenny Bryan / <a href="www.twitter.com/jennybryan>">@JennyBryan</a></li>
+  <li>Daniel Chen / <a href="www.twitter.com/chendaniely">@chendaniely</a></li>
   <li>Camille Avestruz</li>
   <li>David LeBauer</li>
   <li>Cam Macdonell</li>
   <li>Drew Tyre / @atiretoo</li>
-  <li>Rayna Harris / <a href='www.twitter.com/raynaharris'>@raynamharris</a> and the +5 from <a href='https://twitter.com/choleness/status/665613152181092352'>Austin Texas</a> including: Rebecca Tarvin / <a href='www.twitter.com/frogsicles'>@frogsicles</a></li>
+  <li>Rayna Harris / <a href="www.twitter.com/raynaharris">@raynamharris</a> and the +5 from <a href="https://twitter.com/choleness/status/665613152181092352">Austin Texas</a> including: Rebecca Tarvin / <a href="www.twitter.com/frogsicles">@frogsicles</a></li>
   <li>Jon Pipitone</li>
   <li>John Moreau</li>
   <li>Gayathri Swaminathan</li>
@@ -42,36 +48,46 @@ First, thanks to everyone who joined the discussion:
   <li>Azalee Bostroem</li>
 </ul>
 
-Hopefully I got everyone!
+<p>
+  Hopefully I got everyone!
+</p>
 
 <h2>Motivation</h2>
-Last year I <a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002202.html'>asked</a> the <a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/'>discuss list</a>
-if anyone had any experience with turning the <a href='http://software-carpentry.org/lessons.html'>software-carpentry lessons</a> into a university course.
-Bill Mills <a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002203.html'>mentioned</a> that two main hurdles revolve around politics and curriculum control.
-<a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002204.html'>Ethan White</a>
-and <a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002211.html'>Michael Jackson</a> went on to describe their own experiences with setting up a course.
-I want to believe the push for code sharing and reproducible articles from
-<a href='http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261'>Nature</a> and the submission guidelines for
-<a href='http://journals.plos.org/plosone/s/materials-and-software-sharing'>PLOS ONE</a>
-have addressed <a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002205.html'>Greg's</a> initial observations that universities find that lab skills course is not worth graduate credit.  The conversation continues
-<a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002207.html'>here</a>,
-<a href='http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/2014-September/002210.html'>here</a>, and
-a blog post by Damien Irving <a href='http://software-carpentry.org/blog/2014/02/university-course.html'>here</a>.
 
-The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like a good means to revisit the discussion.
+<p>
+  Last year I <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002202.html">asked</a> the <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/">discuss list</a>
+  if anyone had any experience with turning the <a href="{{site.url}}/lessons/">software-carpentry lessons</a> into a university course.
+  Bill Mills <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002203.html">mentioned</a> that two main hurdles revolve around politics and curriculum control.
+  <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002204.html">Ethan White</a>
+  and <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002211.html">Michael Jackson</a> went on to describe their own experiences with setting up a course.
+  I want to believe the push for code sharing and reproducible articles from
+  <a href="http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261">Nature</a> and the submission guidelines for
+  <a href="http://journals.plos.org/plosone/s/materials-and-software-sharing">PLOS ONE</a>
+  have addressed <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002205.html">Greg's</a> initial observations that universities find that lab skills course is not worth graduate credit.  The conversation continues
+  <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002207.html">here</a>,
+  <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/2014-September/002210.html">here</a>, and
+  a blog post by Damien Irving <a href="{{site.url}}/blog/2014/02/university-course.html">here</a>.
+</p>
 
-<h2>Who are we?</h2>
-<a href='http://software-carpentry.org/pages/team.html#chen.daniel'>Daniel Chen</a>
-<a href='http://software-carpentry.org/pages/team.html#timbers.tiffany'>Tiffany Timbers</a>, and
-<a href='http://software-carpentry.org/pages/team.html#bryan.j'>Jenny Bryan</a>
+<p>
+  The Software Carpentry and Data Carpentry Instructor and Helper Retreat seemed like a good means to revisit the discussion.
+</p>
+
+<h2>Who Are We?</h2>
+
+<p>
+  <a href="{{site.url}}/team/#chen.daniel">Daniel Chen</a>,
+  <a href="{{site.url}}/team/#timbers.tiffany">Tiffany Timbers</a>, and
+  <a href="{{site.url}}/team/#bryan.j">Jenny Bryan</a>.
+</p>
 
 <h2>The Roundtable Discussion</h2>
 
 <p>
-  <h4>
-    Earlier this year, Anthony Scopatz and Kathryn Huff published <a href='http://physics.codes/'>Effective Computation in Physics</a> and created a course around the book.
-    Tiffany, can you talk about the <a href='https://phy3009.github.io/PHY3009-2015/'>course</a> you've been beta testing?
-  </h4>
+  <em>
+    Earlier this year, Anthony Scopatz and Kathryn Huff published <a href="http://physics.codes/">Effective Computation in Physics</a> and created a course around the book.
+    Tiffany, can you talk about the <a href="https://phy3009.github.io/PHY3009-2015/">course</a> you've been beta testing?
+  </em>
 </p>
 
 <p>
@@ -79,16 +95,16 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   I decided to use this textbook as my course at Quest.
   The book is based on Python, but many of the principles are language agnostic.
   The book covers many topics SWC teaches, such as Bash, Python, Make, documentation, licenses, and many open science aspects.
-  Katy and Anthony also created a <a href='https://github.com/physics-codes/seminar'>Github repo</a> of annotated iPython (Jupyter) notebooks of the code in the book.
+  Katy and Anthony also created a <a href="https://github.com/physics-codes/seminar">Github repo</a> of annotated iPython (Jupyter) notebooks of the code in the book.
   The notebook annotations are aimed to help those who are using the book as instructors and/or students.
 </p>
 
 <p>
-  <h4>
+  <em>
     A response to my original discuss question revolved around administrative and university department politics on who should and who may teach a course like this.
     For example, some people mentioned that the computer science department will push back to any course involving programming.
     How did you over come these hurdles, or any others?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -104,9 +120,9 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  <h4> How would other people go about piloting a course like this?
+  <em> How would other people go about piloting a course like this?
     For example, I'm just a graduate student, would me getting a faculty to sponsor to run a special topics course be the only way to get started?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -116,13 +132,13 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  <h4>
+  <em>
     How do we organize the SWC material into a 30 week course?
     Should we expand the current material into 30 weeks, or offer 2 half semester courses?
     Bill Mills expressed a concern that a 30 week course could too easily devolve into a Machine Learning/Data science course because instructors overshoot what can be crammed into a computing course.
     SWC tries to teach fundamental skills.
     How do we break up the current material?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -148,9 +164,9 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  <h4>
+  <em>
     Jenny, how do you sneak the SWC material into your existing course?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -158,17 +174,17 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   I use the 2 courses as an excuse to develop each other.
   I mainly teach R and data analysis.  So the SWC git lessons are helpful.
   I don't teach as much Git formally as I should, I maily teach things by doing.
-  I've never drawn <a href='https://twitter.com/chendaniely/status/653973876226031616'>Git concept maps</a> when I teach.
+  I've never drawn <a href="https://twitter.com/chendaniely/status/653973876226031616">Git concept maps</a> when I teach.
   Not sure if this is a good or bad thing.
   But the students end up manage to get the work done.
   I haven't brought SWC material explicitly, yet.
 </p>
 
 <p>
-  <h4>
+  <em>
     If you are teaching SWC as a graduate or undergrad class, you have to assess people.
     What assignments and quizzes do you give so you can get an understanding of how much material they are learning?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -188,13 +204,13 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  <h4>
-    The <a href='http://physics.codes/'>book</a> has 'physics" in the title.
+  <em>
+    The <a href="http://physics.codes/">book</a> has "physics" in the title.
     What department do we put a SWC class under? Should we limit the course to a particular major of students?
     Or have have the course be completely free enrollment?
     Jenny, your class is under Statistics, is your class closed off to just statistics people?
     Who can take your class?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -226,9 +242,9 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  <h4>
+  <em>
     What does the first few weeks of your course look like?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -249,44 +265,54 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   My course is taught in 3.5 weeks instead of 13 weeks.  However, during this time, this is the only course the students are focused on.
   One of the drawbacks about my format is you miss the ability to consolidate information.
   It's more like a 3.5 week long SWC workshop.
-  <br>
+</p>
+
+<p>
   To compare my course with Katy, Anthony, and Bill:
-  <ul>
-    <li>Anthony teaches git right after the shell.  I did this in my course as well.</li>
-    <li>I wanted to use Github as a way to submit homework,
-      so I teach an abbreviated shell (Includes how to navigate the filesystem and creating things lessons).</li>
-  </ul>
+</p>
+
+<ul>
+  <li>Anthony teaches git right after the shell.  I did this in my course as well.</li>
+  <li>I wanted to use Github as a way to submit homework,
+    so I teach an abbreviated shell (Includes how to navigate the filesystem and creating things lessons).</li>
+</ul>
+
+<p>
   I did go with a big final project (maybe a decision I'll be regretting soon?),
   so during the day we learn something for 3 hours and then I have the students implement something from the day's lesson that applies to the final project.
   For example:
-  <ul>
-    <li>Day 1: navigate shell, create things, and shell scripts: The HW was to create a shell script to setup the directory structure for the project.</li>
-    <li>Day 2: Git: The HW was to make a git directory of their final project, and build up from there.</li>
-  </ul>
+</p>
+
+<ul>
+  <li>Day 1: navigate shell, create things, and shell scripts: The HW was to create a shell script to setup the directory structure for the project.</li>
+  <li>Day 2: Git: The HW was to make a git directory of their final project, and build up from there.</li>
+</ul>
+
+<p>
   I try to give a big picture in the beginning of class (e.g. websites hosted on github)
   then show them organized code repository (e.g. a formated readme and folder structure).
   However, I do not get to visualization until near the end of 4th or 5th day.
 </p>
 
 <p>
-  <h4>
+  <em>
     The Gapminder dataset is on CRAN for the R folks, what about the Python people? Is there a CSV?
-  </h4>
+  </em>
 </p>
 
 <p>
-  [J] The <a href='https://cran.r-project.org/web/packages/gapminder/index.html'>package</a>
-  itself contains the <a href='https://github.com/jennybc/gapminder/tree/master/inst'>TSV</a> in non https locations, and <a href='https://github.com/jennybc/gapminder'>github</a>.
+  [J] The <a href="https://cran.r-project.org/web/packages/gapminder/index.html">package</a>
+  itself contains the <a href="https://github.com/jennybc/gapminder/tree/master/inst">TSV</a> in non https locations, and <a href="https://github.com/jennybc/gapminder">github</a>.
 </p>
 
 <p>
-  [T] Nancy Soontiens from UBC has developed a <a href='http://nsoontie.github.io/2015-03-05-ubc/novice/python/Pandas-Lesson.html'>gapminder lesson for Python</a> for the women in science workshop
+  [T] Nancy Soontiens from UBC has developed a <a href="http://nsoontie.github.io/2015-03-05-ubc/novice/python/Pandas-Lesson.html">gapminder lesson for Python</a> for the women in science workshop
 </p>
 
 <p>
-  <h4>
+  <em>
     Jenny teaches a 13 week course and Tiffany you teach a 3.5 week course, How much time per week do you meet? And how do you split up the SWC material throughout the weeks/days
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -308,14 +334,10 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   At the same time the rest of the class is working on their final project.
 </p>
 
-<!--
-[D] What are your opintions on a half-semester course.  Or do you think it's best to be a
--->
-
 <p>
-  <h4>
+  <em>
     What final projects do you have the students work on?  Do you assign them a project or do they bring their own questions?
-  </h4>
+  </em>
 </p>
 
 <p>
@@ -329,9 +351,11 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   Finally, a 8 minute presentation as an IPython (jupyter) notebook.
 </p>
 
-<h4>How much literate programming do you teach?  When do you teach it?</h4>
-
-<p>Literate programming is interweaving code with prose text.</p>
+<p>
+  <em>
+    How much literate programming do you teach?  When do you teach it?
+  </em>
+</p>
 
 <p>
   [T] I get them coding in the notebook and slowly during the first week I show them markdown cells.
@@ -344,7 +368,7 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 <p>
-  [J] I teach <a href='http://rmarkdown.rstudio.com/'>rmarkddown</a> on Day 1.
+  [J] I teach <a href="http://rmarkdown.rstudio.com/">rmarkddown</a> on Day 1.
   It enables them to make a plot which gets them excited.
   <em>Then</em> you can make a web page.
   <em>Then</em> you can easily put it on Github.
@@ -354,48 +378,70 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
 </p>
 
 
-<h4>Grading code and technical work is difficult, how do you do it?</h4>
-
 <p>
-[J] One of other reasons of doing peer review is to get feedback to the students faster than if only the instructor is grading.
+  <em>
+    Grading code and technical work is difficult, how do you do it?
+  </em>
 </p>
 
-<h4>Jenny since you seem to have been doing this for a few years, do you have any available resources to share?</h4>
+<p>
+  [J] One of other reasons of doing peer review is to get feedback to the students faster than if only the instructor is grading.
+</p>
+
+<p>
+  <em>
+    Jenny since you seem to have been doing this for a few years, do you have any available resources to share?
+  </em>
+</p>
 
 <p>
   [J] My writing on the teaching of the course has always been talks.
-  My Courses are online, and I have speaker decks.
-  <ul>
-    <li><a href='http://stat545-ubc.github.io/'>Data wrangling, exploration, and analysis with R</a></li>
-    <li><a href='http://stat540-ubc.github.io/'>Statistical Methods for High Dimensional Biology</a></li>
-  </ul>
-  There's also Ethan White's courses <a href='http://www.datacarpentry.org/semester-biology/syllabus/'>here</a> and <a href='http://www.programmingforbiologists.org/'>here</a>.
+  My courses are online, and I have speaker decks.
+</p>
+
+<ul>
+  <li><a href="http://stat545-ubc.github.io/">Data wrangling, exploration, and analysis with R</a></li>
+  <li><a href="http://stat540-ubc.github.io/">Statistical Methods for High Dimensional Biology</a></li>
+</ul>
+
+<p>
+  There's also Ethan White's courses <a href="http://www.datacarpentry.org/semester-biology/syllabus/">here</a> and <a href="http://www.programmingforbiologists.org/">here</a>.
 <p>
 
-
-<h4>Software and Stats for biology is such a fast paced field, how do you even decide what to teach?</h4>
+<p>
+  <em>
+    Software and Stats for biology is such a fast paced field, how do you even decide what to teach?
+  </em>
+</p>
 
 <p>
   [J] The 2 courses I've taught the past decade is "Data Analysis" where I am chasing technology.
   It's exhausting, but I also want to learn it myself.
-  <br>
+</p>
+
+<p>
   I currently do the opposite in my genomics class.
   I started by chasing the technology for years, but every year almost required a completely new course re-write.
   I eventually generalized it to the key genomics pipelines and statistical analysis.
   For example, multiple comparison and empirical bayes.
   I try not to chase specific sequencing platforms.
   You can only be chasing technology a few places at a time.
-  <br>
+</p>
+
+<p>
   Research wise, I've only been able to put these classes after I've gotten tenure.
   This allmws me to put more effort into developing the course with fewer outside distractions.
   I would say what I'm doing would not mesh well with being super productive research-wise
-  <a href='http://jtleek.com/'>Jeff Leek</a>,
-  <a href='http://www.biostat.jhsph.edu/~rpeng/'>Roger Peng</a>, and
-  <a href='http://rafalab.dfci.harvard.edu/'>Rafael Irizarry</a>, are doing on line courses and super productive research-wise.
+  <a href="http://jtleek.com/">Jeff Leek</a>,
+  <a href="http://www.biostat.jhsph.edu/~rpeng/">Roger Peng</a>, and
+  <a href="http://rafalab.dfci.harvard.edu/">Rafael Irizarry</a>, are doing on line courses and super productive research-wise.
 </p>
 
-
-<h4>Do you have TAs</h4>
+<p>
+  <em>
+    Do you have TAs?
+  </em>
+</p>
 
 <p>
   [J] An <em>army</em> of TAs is critical.  I have 6-7 (not all full time).
@@ -411,7 +457,11 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   However, there are peer helpers outside of the class who are available.
 </p>
 
-<h4>Jenny what's your class enrollment like?</h4>
+<p>
+  <em>
+    Jenny what's your class enrollment like?
+  </em>
+</p>
 
 <p>
   [J] Strictly anecdotally, the people who are most vocal on Github,in class, and enrollment is disproportionately female (in a good way!).
@@ -420,7 +470,11 @@ The Software Carpentry + Data Carpentry Instructor & Helper Retreat seemed like 
   Contrast this with my more professional dialogs on Github, which is mostly male.
 </p>
 
-<h4>Additional Questions/Comments from the audience</h4>
+<p>
+  <em>
+    Additional Questions/Comments from the audience
+  </em>
+</p>
 
 <p>
   [Cam] My university is putting a diploma for Library Techs, probably closer to Data Carpentry.


### PR DESCRIPTION
1.  Most of the content was HTML, so changed suffix to `.html` (needed to trigger the correct renderer).
2.  Replaced `<!-- start excerpt -->` with `<!--more-->` (which is what Jekyll uses).
3.  Replaced inconsistent headings.
4.  Replaced absolute URL stems with variables to future-proof.
5.  Gave the post a comprehensible name.
6.  Used a hyphenated URL to be consistent with other posts.
7.  Added a `redirect_from` so that the previous URL would continue to work.
