### PR TITLE
Removing verbose flag to speed up dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ includes :
 
 ## serve      : run a local server.
 serve : 
-	bundle exec jekyll serve --config _config.yml,_config_dev.yml --verbose
+	bundle exec jekyll serve --config _config.yml,_config_dev.yml
 
 ## site       : build files but do not run a server.
 site : 


### PR DESCRIPTION
The `--verbose` flag produces a _lot_ more output with Jekyll 3, slowing down dev builds noticeably.
