### PR TITLE
Correcting the Google Analytics tracking ID

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -236,21 +236,4 @@ sass:
 #
 # used in _includes/footer_scripts
 
-# FIXME: get a Google analytics tracking ID
-
-google_analytics_tracking_id: UA-60112281-1
-
-#   _                 _     _
-#  | |_ __ ___      _| | __| |_ ___
-#  | __/ _` \ \ /\ / / |/ /| __/ _ \
-#  | || (_| |\ V  V /|   < | || (_) |
-#   \__\__,_| \_/\_/ |_|\_(_)__\___/     More › https://www.tawk.to/knowledgebase/
-#
-#  tawk.to is a free live chat app that lets you monitor and chat
-#  with visitors on your website or from a free customizable page
-#
-#  To load the script add tawkto: true in front matter of each page
-#
-# used in _includes/footer_scripts
-
-# tawkto_embed_uri:
+google_analytics_tracking_id: UA-37305346-1


### PR DESCRIPTION
Site had been deployed with the Google Analytics ID of the template site, rather than the one belonging to admin@software-carpentry.org's Google account, so no data had been collected for two weeks.
