### PR TITLE
Fixing maintainer links

### DIFF
--- a/_includes/people/koch_christina.html
+++ b/_includes/people/koch_christina.html
@@ -6,7 +6,5 @@
     of Wisconsin, Madison, where she serves as a liaison between 
     researchers and campus compute resources.  
     <br/>
-    <strong>Maintainer: <a href="{{site.github_url}}/shell-novice">The Unix Shell</a></strong>
-    <br/>
     <strong>Instructor Trainer</strong>
 </p>

--- a/_includes/people/srinath_ashwin.html
+++ b/_includes/people/srinath_ashwin.html
@@ -6,5 +6,6 @@
     works with Python as much as possible, but can be persuaded to
     code in C, C++ or Fortran.
     <br/>
-    <strong>Maintainer: <a href="{{site.github_url}}/matlab-novice-inflammation">Programming with MATLAB</a></strong>
+    <strong>Maintainer: <a href="{{site.github_url}}/matlab-novice-inflammation">Programming with MATLAB</a>, 
+    <a href="{{site.github_url}}/shell-novice">The Unix Shell</a></strong>
 </p>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -38,7 +38,7 @@ redirect_from:
     <td><a href="{{site.github_url}}/shell-novice" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#devenyi.gabriel">Gabriel Devenyi</a>,
+      <a href="{{site.baseurl}}/team/#devenyi_gabriel">Gabriel Devenyi</a>,
       <a href="{{site.baseurl}}/team/#srinath_ashwin">Ashwin Srinath</a>
     </td>
   </tr>
@@ -48,8 +48,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/git-novice" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#gonzalez.ivan">Ivan Gonzalez</a>,
-      <a href="{{site.baseurl}}/team/#huang.daisie">Daisie Huang</a>
+      <a href="{{site.baseurl}}/team/#gonzalez_ivan">Ivan Gonzalez</a>,
+      <a href="{{site.baseurl}}/team/#huang_daisie">Daisie Huang</a>
     </td>
   </tr>
   <tr id="hg">
@@ -58,7 +58,7 @@ redirect_from:
     <td><a href="{{site.github_url}}/hg-novice" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/hg-novice/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#latornell.d">Doug Latornell</a>
+      <a href="{{site.baseurl}}/team/#latornell_d">Doug Latornell</a>
     </td>
   </tr>
   <tr id="sql">
@@ -67,8 +67,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/sql-novice-survey" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/sql-novice-survey/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#cabunoc.abigail">Abigail Cabunoc</a>,
-      <a href="{{site.baseurl}}/team/#mckay.sheldon">Sheldon McKay</a>
+      <a href="{{site.baseurl}}/team/#cabunoc_abigail">Abigail Cabunoc</a>,
+      <a href="{{site.baseurl}}/team/#mckay_sheldon">Sheldon McKay</a>
     </td>
   </tr>
   <tr id="python">
@@ -77,8 +77,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/python-novice-inflammation" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/python-novice-inflammation/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#bekolay.trevor">Trevor Bekolay</a>,
-      <a href="{{site.baseurl}}/team/#bostroem.a">Azalee Bostroem</a>
+      <a href="{{site.baseurl}}/team/#bekolay_trevor">Trevor Bekolay</a>,
+      <a href="{{site.baseurl}}/team/#bostroem_a">Azalee Bostroem</a>
     </td>
   </tr>
   <tr id="r-prog">
@@ -87,8 +87,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/r-novice-inflammation" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-inflammation/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#blischak.j">John Blischak</a>,
-      <a href="{{site.baseurl}}/team/#haine.denis">Denis Haine</a>
+      <a href="{{site.baseurl}}/team/#blischak_j">John Blischak</a>,
+      <a href="{{site.baseurl}}/team/#haine_denis">Denis Haine</a>
     </td>
   </tr>
   <tr id="r-reproducible">
@@ -97,8 +97,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/r-novice-gapminder" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-gapminder/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#wright.thomas">Thomas Wright</a>,
-      <a href="{{site.baseurl}}/team/#zimmerman.naupaka">Naupaka Zimmerman</a>
+      <a href="{{site.baseurl}}/team/#wright_thomas">Thomas Wright</a>,
+      <a href="{{site.baseurl}}/team/#zimmerman_naupaka">Naupaka Zimmerman</a>
     </td>
   </tr>
   <tr id="matlab">
@@ -107,8 +107,8 @@ redirect_from:
     <td><a href="{{site.github_url}}/matlab-novice-inflammation" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#kiral-kornek.isabell">Isabell Kiral-Kornek</a>,
-      <a href="{{site.baseurl}}/team/#srinath.ashwin">Ashwin Srinath </a>
+      <a href="{{site.baseurl}}/team/#kiral-kornek_isabell">Isabell Kiral-Kornek</a>,
+      <a href="{{site.baseurl}}/team/#srinath_ashwin">Ashwin Srinath </a>
     </td>
   </tr>
   <tr id="make">
@@ -117,7 +117,7 @@ redirect_from:
     <td><a href="{{site.github_url}}/make-novice" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/make-novice/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#jackson.m">Mike Jackson</a>
+      <a href="{{site.baseurl}}/team/#jackson_m">Mike Jackson</a>
     </td>
   </tr>
   <tr id="training">
@@ -126,7 +126,7 @@ redirect_from:
     <td><a href="{{site.github_url}}/instructor-training" target="_blank" class="icon-github" title="icon-github"></a></td>
     <td><a href="{{site.github_io_url}}/instructor-training/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#wilson.g">Greg Wilson</a>
+      <a href="{{site.baseurl}}/team/#wilson_g">Greg Wilson</a>
     </td>
   </tr>
 </table>
@@ -141,42 +141,42 @@ redirect_from:
 <table class="table table-striped">
   <tr>
     <td><a href="http://www.youtube.com/watch?v=T0BE9ApIegc">Version Control and Unit Testing for Scientific Software (SciPy 2013, Part 1)</a></td>
-    <td><a href="{{site.baseurl}}/team/#huff.k">Katy Huff</a></td>
+    <td><a href="{{site.baseurl}}/team/#huff_k">Katy Huff</a></td>
   </tr>
   <tr>
     <td><a href="http://www.youtube.com/watch?v=-shepsIjEZs">Version Control and Unit Testing for Scientific Software (SciPy 2013, Part 2)</a></td>
-    <td><a href="{{site.baseurl}}/team/#davis.m">Matt Davis</a></td>
+    <td><a href="{{site.baseurl}}/team/#davis_m">Matt Davis</a></td>
   </tr>
   <tr>
     <td><a href="http://www.youtube.com/watch?v=j36U6DTKVDY">Version Control and Unit Testing for Scientific Software (SciPy 2013, Part 3)</a></td>
-    <td><a href="{{site.baseurl}}/team/#davis.m">Matt Davis</a></td>
+    <td><a href="{{site.baseurl}}/team/#davis_m">Matt Davis</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=1e26rp6qPbA">Software Carpentry: Lessons Learned (SciPy 2014)</a></td>
-    <td><a href="{{site.baseurl}}/team/#wilson.g">Greg Wilson</a></td>
+    <td><a href="{{site.baseurl}}/team/#wilson_g">Greg Wilson</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/playlist?list=PLkBeePYo-_VCXtMNGDboOL66V-P2-jAoM">Entire workshop at the University of Melbourne (2014)</a></td>
-    <td><a href="{{site.baseurl}}/team/#irving.d">Damien Irving</a></td>
+    <td><a href="{{site.baseurl}}/team/#irving_d">Damien Irving</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=hAHJ0xGKMBk">Software Carpentry: Shell (SciPy 2015)</a></td>
-    <td><a href="{{site.baseurl}}/team/#nielsen.jens">Jens Nielsen</a></td>
+    <td><a href="{{site.baseurl}}/team/#nielsen_jens">Jens Nielsen</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=pB3BFP001co">Software Carpentry: Python (SciPy 2015)</a></td>
-    <td><a href="{{site.baseurl}}/team/#huff.k">Katy Huff</a></td>
+    <td><a href="{{site.baseurl}}/team/#huff_k">Katy Huff</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=hKFNPxxkbO0">Software Carpentry: Git (SciPy 2015)</a></td>
-    <td><a href="{{site.baseurl}}/team/#hart.t">Ted Hart</a></td>
+    <td><a href="{{site.baseurl}}/team/#hart_t">Ted Hart</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=x-5WNfopFTc">Software Carpentry: Scientific Python (SciPy 2015)</a></td>
     <td>
-      <a href="{{site.baseurl}}/team/#hamrick.jessica">Jessica Hamrick</a>
+      <a href="{{site.baseurl}}/team/#hamrick_jessica">Jessica Hamrick</a>
       and
-      <a href="{{site.baseurl}}/team/#davis.m">Matt Davis</a>
+      <a href="{{site.baseurl}}/team/#davis_m">Matt Davis</a>
     </td>
   </tr>
   <tr>
@@ -207,43 +207,43 @@ redirect_from:
     <td>Testing and Continuous Integration with Python</td>
     <td><a href="http://katyhuff.github.io/python-testing" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="https://github.com/katyhuff/python-testing" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#huff.k">Katy Huff</a></td>
+    <td><a href="{{site.baseurl}}/team/#huff_k">Katy Huff</a></td>
   </tr>
   <tr>
     <td>From Excel to a Database</td>
     <td><a href="{{site.github_io_url}}/capstone-novice-spreadsheet-biblio" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.github_url}}/capstone-novice-spreadsheet-biblio" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#wilson.g">Greg Wilson</a></td>
+    <td><a href="{{site.baseurl}}/team/#wilson_g">Greg Wilson</a></td>
   </tr>
   <tr>
     <td>Data Management in the Ocean, Weather and Climate Sciences</td>
     <td><a href="http://damienirving.github.io/capstone-oceanography" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="http://github.com/DamienIrving/capstone-oceanography" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#irving.d">Damien Irving</a></td>
+    <td><a href="{{site.baseurl}}/team/#irving_d">Damien Irving</a></td>
   </tr>
   <tr>
     <td>Controlling a Quadcoptor With Your Mind</td>
     <td><a href="{{site.github_io_url}}/matlab-novice-capstone-biomed" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.github_url}}/matlab-novice-capstone-biomed" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#kiral-kornek.isabell">Isabell Kiral-Kornek</a></td>
+    <td><a href="{{site.baseurl}}/team/#kiral-kornek_isabell">Isabell Kiral-Kornek</a></td>
   </tr>
   <tr>
     <td>Visualizing Your Data on the Web Using D3</td>
     <td><a href="http://isakiko.github.io/D3-visualising-data/" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="https://github.com/isakiko/D3-visualising-data/" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#kiral-kornek.isabell">Isabell Kiral-Kornek</a></td>
+    <td><a href="{{site.baseurl}}/team/#kiral-kornek_isabell">Isabell Kiral-Kornek</a></td>
   </tr>
   <tr>
     <td>Working With Data on the Web</td>
     <td><a href="{{site.github_io_url}}/web-data-python" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="{{site.github_url}}/web-data-python" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#wilson.g">Greg Wilson</a></td>
+    <td><a href="{{site.baseurl}}/team/#wilson_g">Greg Wilson</a></td>
   </tr>
   <tr>
     <td>Intermediate/Advanced R Lessons</td>
     <td><a href="http://resbaz.github.io/r-intermediate-gapminder" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="https://github.com/resbaz/r-intermediate-gapminder" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td><a href="{{site.baseurl}}/team/#ritchie.scott">Scott Ritchie</a></td>
+    <td><a href="{{site.baseurl}}/team/#ritchie_scott">Scott Ritchie</a></td>
   </tr>
   <tr>
     <td>Programming with GAP</td>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -39,7 +39,7 @@ redirect_from:
     <td><a href="{{site.github_io_url}}/shell-novice/reference.html" target="_blank" class="icon-eye" title="icon-eye"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#devenyi.gabriel">Gabriel Devenyi</a>,
-      <a href="{{site.baseurl}}/team/#koch.christina">Christina Koch</a>
+      <a href="{{site.baseurl}}/team/#srinath_ashwin">Ashwin Srinath</a>
     </td>
   </tr>
   <tr id="git">


### PR DESCRIPTION
using "_" instead of "." to separate names.  Built on #240, to be merged after. 
