### PR TITLE
Fix: intructor markers on the map

### DIFF
--- a/assets/js/maps.js
+++ b/assets/js/maps.js
@@ -4,85 +4,88 @@ SWC.maps = (function() {
   var maps = {};
 
   function toggleScrollwheel(map, enabled) {
-      if (map) {
-	  map.setOptions({ scrollwheel: enabled });
-      }
+    if (map) {
+      map.setOptions({ scrollwheel: enabled });
+    }
   }
 
   function add_cluster_event_listeners(clusterer, map, info_window) {
-      google.maps.event.addListener(clusterer, 'clusterclick', function(cluster) {
-        info_window.setPosition(cluster.getCenter());
-        var info_string = "<div class=\"info-window\">";
-        var markers = cluster.getMarkers();
-        for (var i=0; i < markers.length; i++ ) {
-          info_string += markers[i].getTitle();
-        }
-        info_string += "</div>";
-        // reset content so that scroll bar in new content will always be at
-        // top of content
-        info_window.setContent( "<div class=\"info-window\"></div>");
-        info_window.setContent(info_string);
-        info_window.open(map);
-        // when the info window has a scroll bar, we want the mouse scroll wheel
-        //   to scroll in the info window, NOT zoom the map.  Disable map zoom.
-        toggleScrollwheel(map, false);
-      });
-      // zooming changes our clusters completely.  The info window is no longer
-      //  accurate.  Close it.  Make people pick a new cluster or marker.
-      google.maps.event.addListener(map, 'zoom_changed', function(event){
-        info_window.close();
-      });
-      // when the info window is closed, restore mousewheel zoom on the map
-      google.maps.event.addListener(info_window, 'closeclick', function(){
-        toggleScrollwheel(map, true);
-      });
-  };
+    google.maps.event.addListener(clusterer, 'clusterclick', function(cluster) {
+      info_window.setPosition(cluster.getCenter());
+      var info_string = "<div class=\"info-window\">";
+      var markers = cluster.getMarkers();
+      for (var i=0; i < markers.length; i++ ) {
+        info_string += markers[i].getTitle();
+      }
+      info_string += "</div>";
+      // reset content so that scroll bar in new content will always be at
+      // top of content
+      info_window.setContent( "<div class=\"info-window\"></div>");
+      info_window.setContent(info_string);
+      info_window.open(map);
+      // when the info window has a scroll bar, we want the mouse scroll wheel
+      //   to scroll in the info window, NOT zoom the map.  Disable map zoom.
+      toggleScrollwheel(map, false);
+    });
+    // zooming changes our clusters completely.  The info window is no longer
+    //  accurate.  Close it.  Make people pick a new cluster or marker.
+    google.maps.event.addListener(map, 'zoom_changed', function(event){
+      info_window.close();
+    });
+    // when the info window is closed, restore mousewheel zoom on the map
+    google.maps.event.addListener(info_window, 'closeclick', function(){
+      toggleScrollwheel(map, true);
+    });
+  }
 
   maps.pins = function(map, events) {
-      var markers = [];
-      for (var i = 0; i < events.length; i++) {
-	  var coordinates = events[i].geometry.coordinates;
-	  var marker = new google.maps.Marker({
-		  position: new google.maps.LatLng(coordinates[1], coordinates[0]),
-		  map: map,
-		  title: events[i].properties.details,
-		  visible: false   // marker not shown directly, just clustered
-	      });
-	  markers.push(marker);  // For clustering
+    var markers = [];
+    for (var i = 0; i < events.length; i++) {
+      var coordinates = events[i].geometry.coordinates;
+      for (var j = 0; j < events[i].properties.details.length; j++) {
+        var marker = new google.maps.Marker({
+          position: new google.maps.LatLng(coordinates[1], coordinates[0]),
+          map: map,
+          // <br>: when clustered, make names appear one below another
+          title: events[i].properties.details[j] + "<br/>",
+          visible: false   // marker not shown directly, just clustered
+        });
+        markers.push(marker);  // For clustering
       }
-      return markers;
-  }
-        
-  maps.previous = function(element_id, geo_json) {
-      var mapOptions = {
-        zoom: 2,
-        center: new google.maps.LatLng(25,8),
-        mapTypeId: google.maps.MapTypeId.ROADMAP
-      },
-      map = new google.maps.Map(document.getElementById(element_id), mapOptions);
-      var markers = SWC.maps.pins(map, geo_json.features);
+    }
+    return markers;
+  };
 
-      var mcOptions = {
-        zoomOnClick: false,
-        maxZoom: null,
-        gridSize: 25,
-        minimumClusterSize: 1
-      }
-      var mc = new MarkerClusterer(map, markers, mcOptions);
-      info_window = new google.maps.InfoWindow();
-      add_cluster_event_listeners(mc, map, info_window);
-  }
+  maps.previous = function(element_id, geo_json) {
+    var mapOptions = {
+      zoom: 2,
+      center: new google.maps.LatLng(25,8),
+      mapTypeId: google.maps.MapTypeId.ROADMAP
+    },
+    map = new google.maps.Map(document.getElementById(element_id), mapOptions);
+    var markers = SWC.maps.pins(map, geo_json.features);
+
+    var mcOptions = {
+      zoomOnClick: false,
+      maxZoom: null,
+      gridSize: 25,
+      minimumClusterSize: 1
+    };
+    var mc = new MarkerClusterer(map, markers, mcOptions);
+    info_window = new google.maps.InfoWindow();
+    add_cluster_event_listeners(mc, map, info_window);
+  };
 
   maps.draw = function(url, element_id) {
-      var xmlhttp = new XMLHttpRequest();
-      xmlhttp.onreadystatechange=function() {
-	  if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
-	      SWC.maps.previous(element_id, JSON.parse(xmlhttp.responseText));
-	  }
+    var xmlhttp = new XMLHttpRequest();
+    xmlhttp.onreadystatechange=function() {
+      if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {
+        SWC.maps.previous(element_id, JSON.parse(xmlhttp.responseText));
       }
-      xmlhttp.open("GET", url, true);
-      xmlhttp.send();
-  }
+    };
+    xmlhttp.open("GET", url, true);
+    xmlhttp.send();
+  };
 
   return maps;
 })();

--- a/pages/instructors.json
+++ b/pages/instructors.json
@@ -14,7 +14,11 @@ permalink: /instructors.json
       },
       "properties": {
         "marker-color": "#2b3990",
-        "details": "{% for i in airport.instructors %}{{i.name|escape}}{% unless forloop.last %}<br/>{% endunless%}{% endfor %}"
+        "details": [
+          {% for i in airport.instructors %}
+          "{{i.name|escape}}"{% unless forloop.last %},{% endunless%}
+          {% endfor %}
+        ]
       }
     }{% unless forloop.last %},{% endunless %}{% endfor %}
   ]

--- a/pages/workshops_past.json
+++ b/pages/workshops_past.json
@@ -19,7 +19,9 @@ permalink: /workshops_past.json
         },
         "properties": {
           "marker-color": "#2b3990",
-          "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+          "details": [
+            "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+          ]
         }
       }
     {% endunless %}


### PR DESCRIPTION
There was one marker per airport instead of one marker per instructor.
Now there are multiple markers per airport, each marker corresponds to
one instructor.

Additionally fixed: indentation in `maps.js` (what a nightmare it was;
mix of tabs and spaces, and not equal to 2 or 4 spaces but sometimes
to this strange number of 6).

This fixes #110.
