### PR TITLE
Fix current workshops map

### DIFF
--- a/pages/workshops.json
+++ b/pages/workshops.json
@@ -19,7 +19,9 @@ permalink: /workshops.json
         },
         "properties": {
           "marker-color": "#2b3990",
-          "details": "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+          "details": [
+            "<a href='{{workshop.url}}'>{{workshop.venue}}: {{workshop.humandate}}</a>"
+          ]
         }
       }
     {% endunless %}


### PR DESCRIPTION
The error was: again, each workshop's details was treated as array
but they were strings.
