### PR TITLE
Minor grammar fix in site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ title: "Software Carpentry"
 slogan: "Teaching Basic Lab Skills for Scientific Computing"
 
 # The description is used on homepage and in the footer to quickly describe your website. Use a maximum of 150 characters for SEO-purposes.
-description: "Software Carpentry is volunteer non-profit organization dedicated to teaching basic computing skills to researchers."
+description: "Software Carpentry is a volunteer non-profit organization dedicated to teaching basic computing skills to researchers."
 
 # Main author of the website
 # See > authors.yml


### PR DESCRIPTION
Not trying to troll :) but issues with articles (a/an/the) jump out at me when reading a web site. Leaving these out is a common mistake, but makes readability worse.
