### PR TITLE
fixing link to GitHub

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -52,7 +52,7 @@ title: About Us
       <a href="{{site.baseurl}}/join/#discussion">join our mailing lists</a>,
       <a href="{{site.baseurl}}/blog/">read our blog</a>,
       <a href="{{site.data.socialmedia.Twitter.url}}">follow us on Twitter</a>,
-      or browse <a href="{{site.data.socialmedia.GitHub}}">our repositories on GitHub</a>.
+      or browse <a href="{{site.data.socialmedia.GitHub.url}}">our repositories on GitHub</a>.
     </p>
   </div>
 


### PR DESCRIPTION
currently http://software-carpentry.org/about/ doesn't link to https://github.com/swcarpentry

i think this PR will fix this, though never used jekyll so can't be sure...
