### PR TITLE
Ignore vendor dir from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,6 +92,7 @@ exclude:
     - README.md
     - INSTALL.md
     - Makefile
+    - vendor
 
 # The language setting is used in /includes/header.html for html-settings
 language: "en"


### PR DESCRIPTION
For a non-system level install, Bundler suggests install via a local path (eg `bundle install --path vendor/bundle`; see also http://bundler.io/bundle_install.html#path), which installs into the directory `vendor/bundle` inside the cloned repository.

Running `make serve` (aka `bundle exec jekyll ...`) or `make site` etc in this instance now considers the `vendor` directory as part of the build, drawing in errant documents like so:

```
Configuration file: /home/david/dev/tmp/website/_config.yml
            Source: /home/david/dev/tmp/website
       Destination: /home/david/dev/tmp/website/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.1.0/gems/jekyll-3.0.3/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

This PR adds the `vendor` directory to the `excludes` option for Jekyll, avoiding this issue and allowing the build to succeed.
