### PR TITLE
Add note about PyYAML requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ $ bundle install
 to install Jekyll and the software it depends on.
 You may consult [Using Jekyll with Pages](https://help.github.com/articles/using-jekyll-with-pages/) for further instructions.
 
-You will also need [Python 3](http://python.org/) in order to re-generate the [data files](#details) the site depends on.
+You will also need [Python 3](http://python.org/) with
+[PyYAML](https://pypi.python.org/pypi/PyYAML/) available in order to
+re-generate the [data files](#details) the site depends on.
 
 ## Previewing <a name="previewing"></a>
 


### PR DESCRIPTION
The `make includes` script requires the `yaml` module for Python, which isn't part of the standard library.  This adds a note so the user knows they need to install it.

A better option would be a `requirements.txt` file, but since `make includes` seems to be going away (?) just documenting this in the meantime should work.
