### PR TITLE
Updating the link to the website github repo

### DIFF
--- a/pages/faq.html
+++ b/pages/faq.html
@@ -674,7 +674,7 @@ redirect_from:
       All of our slides, notes, and example programs are in Git repositories at
       <a href="{{site.github_url}}">{{site.github_url}}</a>,
       and the source for our website (including our blog) at
-      <a href="{{site.github_url}}/site">{{site.github_url}}/site</a>.
+      <a href="{{site.github_url}}/website">{{site.github_url}}/website</a>.
     </p>
   </dd>
 


### PR DESCRIPTION
Moving from the old /site repository link to the new /website repository per the soft redirect message in github when visiting http://github.com/swcarpentry/site
