### PR TITLE
Fee clarification

### DIFF
--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -38,7 +38,7 @@ redirect_from:
     <h4>Self-Organized Workshops: Optional Donation</h4>
     <p>
       Software Carpentry welcomes you to organize and run your own workshop
-      without administrative support from the Software Carpentry Foundation
+      without administrative assistance from the Software Carpentry Foundation
       <strong>by optional donation</strong>. In order to use the
       Software Carpentry name and logo at your event, we only
       require that you follow our curriculum, have at least one badged instructor teaching and

--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -24,37 +24,48 @@ redirect_from:
   please <a href="http://www.datacarpentry.org/workshops-host/">visit their web site</a>.
 </p>
 
+<h3>Expenses and Fees</h3>
+
 <p>
   Our instructors are volunteers, and so are not paid for their
-  teaching, but host sites are required to cover their travel and
-  accommodation costs. In addition, the Software Carpentry Foundation
-  charges an administration fee for workshops that it helps organize
-  at institutions which are not partners or affiliates.  For workshop
-  requests received after September 1, 2015, these fees are:
+  teaching, but host sites are <strong>required to cover travel and
+  accommodation costs for any instructors visiting from out of town</strong>.
+  The Software Carpentry Foundation offers three fee schedules
+  for workshops:
 </p>
 <ul>
   <li>
+    <h4>Self-Organized Workshops: Optional Donation</h4>
     <p>
-      If you have organized the workshop yourself
-      (e.g., have found instructors and are managing inquiries),
-      we are happy to help by setting up an Eventbrite registration page
-      and creating pre- and post-workshop assessment questionnaires.
-      In this case,
-      we ask for (but do not require) a donation,
-      and recommend $500 as a suitable amount.
+      Software Carpentry welcomes you to organize and run your own workshop
+      <strong>by optional donation</strong>. In order to use the
+      Software Carpentry name and logo at your event, we only
+      require that you follow
+      <a href='http://software-carpentry.org/lessons/'>our curriculum</a>,
+      and have at least one <a href=''>badged instructor</a> teaching and
+      co-organizing your event. In order to help Software Carpentry
+      continue operating and offering workshops around the world,
+      we ask for (but <strong>do not require</strong>) a donation,
+      and recommend $500 USD as a suitable amount.
     </p>
   </li>
   <li>
+    <h4>Nonprofit Organization: $1250-$2500</h4>
     <p>
       If you are a not-for-profit, such as a university or government
-      lab: US$2500 if you are not a Software Carpentry Foundation
-      partner, and $1250 if you are, but require our help.
+      lab, the Software Carpentry Foundation will organize a workshop
+      for you (not including instructor travel and accommodation
+      costs) for $2500 USD if you are not a Software Carpentry Foundation
+      partner, and $1250 USD if you are.
     </p>
   </li>
   <li>
+    <h4>For-Profit Institution: $10000</h4>
     <p>
-      If you are a for-profit institution, such as a company:
-      US$10,000, of which three quarters is used to underwrite
+      If you are a for-profit institution, such as a company,
+      the Software Carpentry Foundation will organize a workshop
+      for you (not including instructor travel and accommodation
+      costs) for $10,000 USD, of which three quarters is used to underwrite
       workshops at institutions that could otherwise not afford
       them.
     </p>
@@ -63,7 +74,9 @@ redirect_from:
 <p>
   We strive to be a global project and support diversity in science.
   If you wish to offer a workshop that would further these goals,
-  please <a href="mailto:{{site.contact}}">contact us</a> regarding a waiver for the administration fee.
+  please <a href="mailto:{{site.contact}}">contact us</a> regarding
+  a waiver for the administration fee at the nonprofit and for-profit
+  scales. Waivers are not required for self-organized workshops.
 </p>
 <p>
   Note: if you hosted a workshop in 2015 before September 1,

--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -50,13 +50,12 @@ redirect_from:
     </p>
   </li>
   <li>
-    <h4>Nonprofit Organization: $1250-$2500</h4>
+    <h4>Nonprofit Organization: $2500</h4>
     <p>
       If you are a not-for-profit, such as a university or government
       lab, the Software Carpentry Foundation will organize a workshop
       for you (not including instructor travel and accommodation
-      costs) for $2500 USD if you are not a Software Carpentry Foundation
-      partner, and $1250 USD if you are.
+      costs) for $2500 USD.
     </p>
   </li>
   <li>

--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -38,6 +38,7 @@ redirect_from:
     <h4>Self-Organized Workshops: Optional Donation</h4>
     <p>
       Software Carpentry welcomes you to organize and run your own workshop
+      without administrative support from the Software Carpentry Foundation
       <strong>by optional donation</strong>. In order to use the
       Software Carpentry name and logo at your event, we only
       require that you follow our curriculum, have at least one badged instructor teaching and

--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -40,10 +40,9 @@ redirect_from:
       Software Carpentry welcomes you to organize and run your own workshop
       <strong>by optional donation</strong>. In order to use the
       Software Carpentry name and logo at your event, we only
-      require that you follow
-      <a href='http://software-carpentry.org/lessons/'>our curriculum</a>,
-      and have at least one <a href=''>badged instructor</a> teaching and
-      co-organizing your event. In order to help Software Carpentry
+      require that you follow our curriculum, have at least one badged instructor teaching and
+      co-organizing your event, and <a href="mailto:{{site.contact}}">let us know</a>
+      that you're organizing a workshop. In order to help Software Carpentry
       continue operating and offering workshops around the world,
       we ask for (but <strong>do not require</strong>) a donation,
       and recommend $500 USD as a suitable amount.


### PR DESCRIPTION
Clarification of fees charged for SWC workshops. Not to be merged before approval from the SC. Change summary:
- clearly bullet three fee schedules to distinguish between them
- clarify that waivers are not required for self-organized workshops
- clarify that travel and accommodation costs are the host's responsibility beyond SCF fees
- do not commit to any administrative support for self-organized workshops
