### PR TITLE
draft of pages for Subcommittees

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -73,6 +73,8 @@
     url: "/join/projects/"
   - title: "Help Wanted"
     url: "/join/help/"
+  - title: "Subcommittees and Task Forces"
+    url: "/join/subcom_and_tf/"
   - title: "Reading Material"
     url: "/reading/"
 

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -21,8 +21,12 @@ The existing Subcommittees and Task Forces are always happy to have new people g
     <td><strong>Activities</strong></td>
   </tr>
   <tr>
-    <td><a href='/join/subcom/mentoring'>Mentoring</a></td>
-    <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor & Helper Retreat</td>
+    <td><a href='/join/subcom/mentoring/'>Mentoring</a></td>
+    <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor &amp; Helper Retreat</td>
+  </tr>
+  <tr>
+    <td><a href='/join/subcom/maintainers/'>Maintainers</a></td>
+    <td>Lesson Maintenance, Lesson and Workshop Templates</td>
   </tr>
 </table>
 

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -48,7 +48,7 @@ The existing Subcommittees and Task Forces are always happy to have new people g
   <tr>
     <td>AMY Development</td>
     <td>Plan and implement features for the Carpentries' member database, AMY.</td>
-    <td>Coming Soon!</td>
+    <td><a href='https://github.com/swcarpentry/amy/issues'>Open an Issue</a></td>
   </tr>
 </table>
 

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -21,12 +21,12 @@ The existing Subcommittees and Task Forces are always happy to have new people g
     <td><strong>Activities</strong></td>
   </tr>
   <tr>
-    <td><a href='/join/subcom/mentoring/'>Mentoring</a></td>
-    <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor &amp; Helper Retreat</td>
-  </tr>
-  <tr>
     <td><a href='/join/subcom/maintainers/'>Maintainers</a></td>
     <td>Lesson Maintenance, Lesson and Workshop Templates</td>
+  </tr>
+  <tr>
+    <td><a href='/join/subcom/mentoring/'>Mentoring</a></td>
+    <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor &amp; Helper Retreat</td>
   </tr>
 </table>
 
@@ -35,10 +35,17 @@ The existing Subcommittees and Task Forces are always happy to have new people g
   <tr>
     <td><strong>Task Force</strong></td>
     <td><strong>Goals</strong></td>
+    <td><strong>Get Involved</strong></td>
   </tr>
   <tr>
-    <td>Coming Soon</td>
-    <td><a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>propose something!</a></td>
+    <td>African Guides</td>
+    <td>Help instructor trainees from the April 2016 Instructor Training workshop to qualify as instructors.</td>
+    <td>Coming Soon!</td>
+  </tr>
+  <tr>
+    <td>AMY Development</td>
+    <td>Plan and implement features for the Carpentries' member database, AMY.</td>
+    <td>Coming Soon!</td>
   </tr>
 </table>
 

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -19,14 +19,17 @@ The existing Subcommittees and Task Forces are always happy to have new people g
   <tr>
     <td><strong>Subcommittee Webpage</strong></td>
     <td><strong>Activities</strong></td>
+    <td><strong>Contact</strong></td>
   </tr>
   <tr>
     <td><a href='/join/subcom/maintainers/'>Maintainers</a></td>
     <td>Lesson Maintenance, Lesson and Workshop Templates</td>
+    <td><a href='mailto:lessons@software-carpentry.org'>lessons@software-carpentry.org</a></td>
   </tr>
   <tr>
     <td><a href='/join/subcom/mentoring/'>Mentoring</a></td>
     <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor &amp; Helper Retreat</td>
+    <td><a href='mailto:mentoring@lists.software-carpentry.org'>mentoring@lists.software-carpentry.org</a></td>
   </tr>
 </table>
 
@@ -35,12 +38,12 @@ The existing Subcommittees and Task Forces are always happy to have new people g
   <tr>
     <td><strong>Task Force</strong></td>
     <td><strong>Goals</strong></td>
-    <td><strong>Get Involved</strong></td>
+    <td><strong>Contact</strong></td>
   </tr>
   <tr>
     <td>African Guides</td>
     <td>Help instructor trainees from the April 2016 Instructor Training workshop to qualify as instructors.</td>
-    <td>Coming Soon!</td>
+    <td><a href='https://twitter.com/cloudaus'>Belinda Weaver</a></td>
   </tr>
   <tr>
     <td>AMY Development</td>

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -5,31 +5,7 @@ title: Subcommittees and Task Forces
 ---
 
 <p>
-Teaching and organizing workshops isn't the only way to get involved in Software Carpentry; our activities are supported behind-the-scenes by Subcommittees and Task Forces that help solve problems, explore new ideas and provide much-needed service work to the Software Carpentry community worldwide. Subcommittees and Task Forces are proposed and run by community members like you - check out the links below to see how to get started.
-</p>
-
-<h2>How to Propose a New Subcommittee or Task Force</h2>
-
-<p>
-Do you have an idea for an activity or service that would make Software Carpentry even more awesome to participate in for its instructors or students? Is there a project, tool or document that would benefit you and your community?
-</p>
-
-<p>
-We are very excited to hear and support your ideas! However, we do need to read and review all proposals.
-</p>
-
-<p>
-<strong>To propose a new subcommittee or task force</strong>, please read the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>information here</a>. The key elements of a proposal that the Steering Committee will be looking for (and which we will help you with!) are:
-</p>
-
-<ul>
-  <li><strong>Specificity</strong>: do you have a specific goal, with a plan and timeline to achieve it? Nothing has to be cast in stone at this point, but the more specific your plan, the easier it will be for you to put it into action.</li>
-  <li><strong>Resources</strong>: have you anticipated what you’ll need, in terms of personnel, tools, external support and budget? Modest budgets will be available to support Subcommittee and Task Force activities, to be approved on a per-item basis by the Steering Committee; we will be looking for realistic (but non-binding) predictions of what you’ll need to succeed.</li>
-  <li><strong>Community Fit</strong>: is there clear vision for how your project will advance Software Carpentry’s mission, or enrich our community? The Steering Committee will be coordinating all these groups by making sure we all work together effectively; understanding how your project fits into the bigger picture is an important first step.</li>
-</ul>
-
-<p>
-More details are in the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>full instructions</a>; if you have any questions or anything is unclear, don’t hesitate to ask! <strong>The most important step is to let us know your ideas</strong>, so after reading the link above, <a href='https://github.com/swcarpentry/board/issues'>open an issue</a> and let us know what you’re thinking, even if you don’t yet know how to answer all the points above; the Steering Committee will happily help you craft a great proposal.
+Teaching and organizing workshops isn't the only way to get involved in Software and Data Carpentry; our activities are supported behind-the-scenes by Subcommittees and Task Forces that help solve problems, explore new ideas and provide much-needed service work to the Carpentry community worldwide. Subcommittees and Task Forces are proposed and run by community members like you - check out the links below to see what's already happening and how to get started on something new.
 </p>
 
 <h2>Current Subcommittees and Task Forces</h2>
@@ -61,3 +37,27 @@ The existing Subcommittees and Task Forces are always happy to have new people g
     <td><a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>propose something!</a></td>
   </tr>
 </table>
+
+<h2>How to Propose a New Subcommittee or Task Force</h2>
+
+<p>
+Do you have an idea for an activity or service that would make the Carpentries even more awesome to participate in for its instructors or students? Is there a project, tool or document that would benefit you and your community?
+</p>
+
+<p>
+We are very excited to hear and support your ideas! However, we do need to read and review all proposals.
+</p>
+
+<p>
+<strong>To propose a new subcommittee or task force</strong>, please read the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>information here</a>. The key elements of a proposal that the Steering Committee will be looking for (and which we will help you with!) are:
+</p>
+
+<ul>
+  <li><strong>Specificity</strong>: do you have a specific goal, with a plan and timeline to achieve it? Nothing has to be cast in stone at this point, but the more specific your plan, the easier it will be for you to put it into action.</li>
+  <li><strong>Resources</strong>: have you anticipated what you’ll need, in terms of personnel, tools, external support and budget? Modest budgets will be available to support Subcommittee and Task Force activities, to be approved on a per-item basis by the Steering Committee; we will be looking for realistic (but non-binding) predictions of what you’ll need to succeed.</li>
+  <li><strong>Community Fit</strong>: is there clear vision for how your project will advance Software and/or Data Carpentry’s mission, or enrich our community? The Steering Committee will be coordinating all these groups by making sure we all work together effectively; understanding how your project fits into the bigger picture is an important first step.</li>
+</ul>
+
+<p>
+More details are in the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>full instructions</a>; if you have any questions or anything is unclear, don’t hesitate to ask! <strong>The most important step is to let us know your ideas</strong>, so after reading the link above, <a href='https://github.com/swcarpentry/board/issues'>open an issue</a> and let us know what you’re thinking, even if you don’t yet know how to answer all the points above; the Steering Committee will happily help you craft a great proposal.
+</p>

--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -1,0 +1,63 @@
+---
+layout: page-fullwidth
+permalink: /join/subcom_and_tf
+title: Subcommittees and Task Forces
+---
+
+<p>
+Teaching and organizing workshops isn't the only way to get involved in Software Carpentry; our activities are supported behind-the-scenes by Subcommittees and Task Forces that help solve problems, explore new ideas and provide much-needed service work to the Software Carpentry community worldwide. Subcommittees and Task Forces are proposed and run by community members like you - check out the links below to see how to get started.
+</p>
+
+<h2>How to Propose a New Subcommittee or Task Force</h2>
+
+<p>
+Do you have an idea for an activity or service that would make Software Carpentry even more awesome to participate in for its instructors or students? Is there a project, tool or document that would benefit you and your community?
+</p>
+
+<p>
+We are very excited to hear and support your ideas! However, we do need to read and review all proposals.
+</p>
+
+<p>
+<strong>To propose a new subcommittee or task force</strong>, please read the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>information here</a>. The key elements of a proposal that the Steering Committee will be looking for (and which we will help you with!) are:
+</p>
+
+<ul>
+  <li><strong>Specificity</strong>: do you have a specific goal, with a plan and timeline to achieve it? Nothing has to be cast in stone at this point, but the more specific your plan, the easier it will be for you to put it into action.</li>
+  <li><strong>Resources</strong>: have you anticipated what you’ll need, in terms of personnel, tools, external support and budget? Modest budgets will be available to support Subcommittee and Task Force activities, to be approved on a per-item basis by the Steering Committee; we will be looking for realistic (but non-binding) predictions of what you’ll need to succeed.</li>
+  <li><strong>Community Fit</strong>: is there clear vision for how your project will advance Software Carpentry’s mission, or enrich our community? The Steering Committee will be coordinating all these groups by making sure we all work together effectively; understanding how your project fits into the bigger picture is an important first step.</li>
+</ul>
+
+<p>
+More details are in the <a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>full instructions</a>; if you have any questions or anything is unclear, don’t hesitate to ask! <strong>The most important step is to let us know your ideas</strong>, so after reading the link above, <a href='https://github.com/swcarpentry/board/issues'>open an issue</a> and let us know what you’re thinking, even if you don’t yet know how to answer all the points above; the Steering Committee will happily help you craft a great proposal.
+</p>
+
+<h2>Current Subcommittees and Task Forces</h2>
+
+<p>
+The existing Subcommittees and Task Forces are always happy to have new people get involved; check out what's going on in these active groups:
+</p>
+
+<h3>Subcommittees</h3>
+<table>
+  <tr>
+    <td><strong>Subcommittee Webpage</strong></td>
+    <td><strong>Activities</strong></td>
+  </tr>
+  <tr>
+    <td><a href='/join/subcom/mentoring'>Mentoring</a></td>
+    <td>Instructor Discussion Sessions, Post-Instructor Training Support, Instructor & Helper Retreat</td>
+  </tr>
+</table>
+
+<h3>Task Forces</h3>
+<table>
+  <tr>
+    <td><strong>Task Force</strong></td>
+    <td><strong>Goals</strong></td>
+  </tr>
+  <tr>
+    <td>Coming Soon</td>
+    <td><a href='https://github.com/swcarpentry/board/blob/master/subcommittees/proposal_instructions.md'>propose something!</a></td>
+  </tr>
+</table>

--- a/pages/subcom_maintainers.html
+++ b/pages/subcom_maintainers.html
@@ -4,7 +4,7 @@ permalink: /join/subcom/maintainers/
 email: 'lessons@software-carpentry.org'
 subcomName: Maintainers
 purpose: "The Maintainers Subcommittee is responsible for maintaining and publishing our core lessons, and for overseeing development of the workshop and lesson templates."
-join: "<p>This committee is comprised of the maintainers of <a href="{{site.baseurl}}/lessons/">our core lessons</a>.</p>"
+join: "<p>This committee is comprised of the maintainers of <a href='{{site.baseurl}}/lessons/'>our core lessons</a>.</p>"
 activities: 
   - title: "Lesson Maintenance"
     description: "Maintainers oversee the editing and merging of proposed improvements to our core lessons."

--- a/pages/subcom_maintainers.html
+++ b/pages/subcom_maintainers.html
@@ -1,0 +1,39 @@
+---
+layout: page-fullwidth
+permalink: /join/subcom/maintainers/
+email: 'lessons@software-carpentry.org'
+subcomName: Maintainers
+purpose: "The Maintainers Subcommittee is responsible for maintaining and publishing our core lessons, and for overseeing development of the workshop and lesson templates."
+join: "<p>This committee is comprised of the maintainers of <a href="{{site.baseurl}}/lessons/">our core lessons</a>.</p>"
+activities: 
+  - title: "Lesson Maintenance"
+    description: "Maintainers oversee the editing and merging of proposed improvements to our core lessons."
+  - title: "Template Development"
+    description: "Maintainers develop and vote on changes to the templates and tooling used for our workshops and lessons."
+  - title: "Publication"
+    description: "Maintainers decide on the publication (release) schedule for lessons."
+---
+
+<h1>{{page.subcomName}} Subcommittee</h1>
+
+<h3>Purpose and Scope</h3>
+<p>{{page.purpose}}</p>
+
+<h3>What We Do</h3>
+<ul>
+  {% for activity in page.activities %}
+    <li>
+      <h4>{{activity.title}}</h4>
+      <p>{{activity.description}}</p>
+    </li>
+  {% endfor %}
+</ul>
+
+<h3>Join Us</h3>
+{{page.join}}
+
+<h3>Current Members</h3>
+<p>
+  Please see <a href="{{site.baseurl}}/lessons">the lessons page</a>
+  for an up-to-date list of lesson maintainers.
+</p>

--- a/pages/subcom_mentorship.html
+++ b/pages/subcom_mentorship.html
@@ -62,7 +62,7 @@ members:
 
 <h1>{{page.subcomName}} Subcommittee</h1>
 
-<h3>Purpose & Scope</h3>
+<h3>Purpose and Scope</h3>
 <p>{{page.purpose}}</p>
 
 <h3>What We Do</h3>

--- a/pages/subcom_mentorship.html
+++ b/pages/subcom_mentorship.html
@@ -1,6 +1,6 @@
 ---
 layout: page-fullwidth
-permalink: /join/subcom/mentoring
+permalink: /join/subcom/mentoring/
 email: 'mentoring@lists.software-carpentry.org'
 subcomName: Mentoring
 purpose: 'The Mentoring Subcommittee was established in 2015 to develop and maintain a mentorship program to support instructors as they progress through training, teaching, curriculum development, and other community-related activities. We help promote community-building and networking by providing (virtual) spaces where instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges.'

--- a/pages/subcom_mentorship.html
+++ b/pages/subcom_mentorship.html
@@ -1,0 +1,93 @@
+---
+layout: page-fullwidth
+permalink: /join/subcom/mentoring
+email: 'mentoring@lists.software-carpentry.org'
+subcomName: Mentoring
+purpose: 'The Mentoring Subcommittee was established in 2015 to develop and maintain a mentorship program to support instructors as they progress through training, teaching, curriculum development, and other community-related activities. We help promote community-building and networking by providing (virtual) spaces where instructors from all over the world can share teaching success stories and discuss strategies for overcoming challenges.'
+join: "<p>We welcome new members to the Mentoring Subcommittee with open arms. If you are interested in joining our community-building efforts, please send a email to <a href='mailto:mentoring@lists.software-carpentry.org'>mentoring@lists.software-carpentry.org</a>.</p><p>Currently, members of the Mentoring Subcommittee spend around 2-8 hours each month with subcommittee activities, these include:<ul><li>attending bi-month subcommittee meetings where ongoing projects and new ideas are discussed; see <a href='http://pad.software-carpentry.org/scf-mentoring'>our meeting etherpad</a></li><li>hosting one or two instructor discussion sessions per month; <a href='http://pad.software-carpentry.org/instructor-discussion'>see the discussion etherpads</a></li><li>writing blog posts about our ongoing and proposed activities</li><li>and possibly more! We're open to new ideas!</li></ul></p>"
+activities: 
+  - title: "Instructor Discussion Sessions"
+    description: "Each week, we host four instructor discussion sessions. The sessions provide a forum where experienced and novice instructors can discuss past and/or upcoming workshops. Instructors who have just taught, are about to teach, or have just completed instructor training will  receive an email invitation to these meetings, but these sessions are open to anyone."
+  - title: "Instructor-Helper Retreat"
+    description: "In November 2015, Software Carpentry and Data Carpentry instructors and helpers got together together at sites around the world for a day of sharing skills, trying out new lessons and ideas and discussing all things instructor and helper related."
+  - title: "Archived: Pre- and Post- Workshop Debriefing Session"
+    description: "Before launching the Instructor Discussion Sessions, we used to host separate pre- and post-workshop debriefing sessions. We are grateful to all the hosts and participants who attended these sessions. As a group, we posted <a href='http://software-carpentry.org/blog/categories/#debriefing'>25 post-workshop debriefing blogs</a> last year. Click <a href='http://software-carpentry.org/blog/categories/#debriefing'>this link</a> for links to these blogs sorted by date. "
+members:
+  - name: "Belinda Weaver"
+    twitter: "@cloudaus"
+    twitterURL: "https://twitter.com/cloudaus"     
+  - name:  "Bill Mills"
+    twitter: "@billdoesphysics"
+    twitterURL: "https://twitter.com/billdoesphysics"   
+  - name:  "Carol Willing"
+    twitter: "@WillingCarol"
+    twitterURL: "https://twitter.com/WillingCarol"   
+  - name:  "Christina Koch, Chair"
+    twitter: "@_christinaLK"
+    twitterURL: "https://twitter.com/_christinaLK"   
+  - name:  "Daniel Chen"
+    twitter: "@chendaniely"
+    twitterURL: "https://twitter.com/chendaniely"  
+  - name: "Karin Lagesen"
+    twitter: "@karinlag"
+    twitterURL: "https://twitter.com/karinlag"   
+  - name: "Kate Hertweck"
+    twitter: "@k8hert"
+    twitterURL: "https://twitter.com/k8hert"   
+  - name:  "Marian Schmidt"
+    twitter: "@micro_marian"
+    twitterURL: "https://twitter.com/micro_marian"   
+  - name: "Mariela Perignon"
+    twitter: ""
+    twitterURL: "" 
+  - name: "Michael Sarahan"
+    twitter: ""
+    twitterURL: "" 
+  - name: "Phil Rosenfield"
+    twitter: "@philrosenfield"
+    twitterURL: "https://twitter.com/philrosenfield"  
+  - name: "Rayna Harris"
+    twitter: "@raynamharris"
+    twitterURL: "https://twitter.com/raynamharris"   
+  - name: "Susan McClatchy"
+    twitter: "@SueMcclatchy"
+    twitterURL: "https://twitter.com/SueMcclatchy"   
+  - name: "Tiffany Timbers"
+    twitter: "@TiffanyTimbers"
+    twitterURL: "https://twitter.com/TiffanyTimbers"  
+  - name: "Tracy Teal"
+    twitter: "@tracykteal"
+    twitterURL: "https://twitter.com/tracykteal"  
+---
+
+<h1>{{page.subcomName}} Subcommittee</h1>
+
+<h3>Purpose & Scope</h3>
+<p>{{page.purpose}}</p>
+
+<h3>What We Do</h3>
+<ul>
+  {% for activity in page.activities %}
+    <li>
+      <h4>{{activity.title}}</h4>
+      <p>{{activity.description}}</p>
+    </li>
+  {% endfor %}
+</ul>
+
+<h3>Join Us</h3>
+<strong>Email the <a href='mailto:{{page.email}}'>{{page.subcomName}} Subcommittee</a> to get involved.</strong>
+<p>{{page.join}}</p>
+
+<h3>Current Members</h3>
+<div class='row'>
+  {% for person in page.members %}
+    <div class='medium-6 columns'>
+      <strong>{{person.name}}</strong>
+      <a href='{{person.twitterURL}}'>{{person.twitter}}</a>
+    </div>
+  {% endfor %}
+  <div></div>
+</div>
+
+

--- a/pages/subcom_template.html
+++ b/pages/subcom_template.html
@@ -29,7 +29,7 @@ members:
 
 <h1>{{page.subcomName}} Subcommittee</h1>
 
-<h3>Purpose & Scope</h3>
+<h3>Purpose and Scope</h3>
 <p>{{page.purpose}}</p>
 
 <h3>What We Do</h3>

--- a/pages/subcom_template.html
+++ b/pages/subcom_template.html
@@ -1,0 +1,59 @@
+---
+layout: page-fullwidth
+permalink: /join/subcom/template
+email: "youremail@lists.software-carpentry.org"
+subcomName: Template
+purpose: "A one paragraph description of the purpose and scope of this subcommittee."
+join: "Some text encouraging people to get involved, and describing what opportunities there are to participate."
+activities: 
+  - title: "Activity One"
+    description: "Describe activity one"
+  - title: "Activity Two"
+    description: "Describe activity two"
+  - title: "Activity Three"
+    description: "Describe activity three"
+members:
+  - name: "First Last A"
+    twitter: "@first_lasts_twitter_handle"
+    twitterURL: "https://twitter.com/first_lasts_twitter_handle"
+  - name: "First Last B"
+    twitter: "@first_lasts_twitter_handle"
+    twitterURL: "https://twitter.com/first_lasts_twitter_handle"
+  - name: "First Last C"
+    twitter: "@first_lasts_twitter_handle"
+    twitterURL: "https://twitter.com/first_lasts_twitter_handle"
+  - name: "First Last D"
+    twitter: "@first_lasts_twitter_handle"
+    twitterURL: "https://twitter.com/first_lasts_twitter_handle"
+---
+
+<h1>{{page.subcomName}} Subcommittee</h1>
+
+<h3>Purpose & Scope</h3>
+<p>{{page.purpose}}</p>
+
+<h3>What We Do</h3>
+<ul>
+  {% for activity in page.activities %}
+    <li>
+      <h4>{{activity.title}}</h4>
+      <p>{{activity.description}}</p>
+    </li>
+  {% endfor %}
+</ul>
+
+<h3>Join Us</h3>
+<strong>Email the <a href="mailto:{{page.email}}">{{page.subcomName}} Subcommittee</a> to get involved.</strong>
+<p>{{page.join}}</p>
+
+<h3>Current Members</h3>
+<div class='row'>
+  {% for person in page.members %}
+    <div class='medium-6 columns'>
+      <strong>{{person.name}}</strong>
+      <a href='{{person.twitterURL}}'>{{person.twitter}}</a>
+    </div>
+  {% endfor %}
+  <div></div>
+</div>
+


### PR DESCRIPTION
There has been some discussion recently of providing a landing page for the Mentorship Subcommittee on the SWC website (see https://github.com/swcarpentry/board/pull/102, ping @raynamharris); this PR adds:
- the aforementioned Mentorship page, with text pulled verbatim from the PR linked above
- a template for general Subcommittee pages

~~Still todo: how to link to these? I would do a 'Subcommittees & Task Forces' link in the 'Get Involved' dropdown that navigates to a landing page for the whole subcom / tf program, which then links to the specific groups.~~ **Edit:** <-- implemented below
