### PR TITLE
pages/join.html: Update discuss@ volume estimate

### DIFF
--- a/pages/join.html
+++ b/pages/join.html
@@ -75,7 +75,7 @@ an entry to
       The main channel for discussion of direction and technology.
     </td>
     <td>
-      5-20 messages/week
+      30-40 messages/week
     </td>
     <td>
       unmoderated


### PR DESCRIPTION
Looking through the month-summaries from the [archives](http://lists.software-carpentry.org/pipermail/discuss_lists.software-carpentry.org/), here's how
discuss@ has been going for 2016:
- January: ~4 messages per day
- February: ~6 messages per day
- March: ~6 messages per day
- April: ~5 messages per day
- May: ~20 messages per day so far

I'm not sure where the old estimate came from (in this repo it's from
64b294c9, Importing alpha content, 2015-11-21), and I haven't looked
at previous years, but I expect it's been a while since there were
only five messages a week ;).
