### PR TITLE
Fixed mailing lists links

### DIFF
--- a/pages/join.html
+++ b/pages/join.html
@@ -66,10 +66,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/discuss_lists.software-carpentry.org">discuss</a>
+      <a href="{{site.mailing_lists}}/listinfo/discuss">discuss</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/discuss_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/discuss/">(archives)</a>
     </td>
     <td>
       The main channel for discussion of direction and technology.
@@ -83,10 +83,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/instructors_lists.software-carpentry.org">instructors</a>
+      <a href="{{site.mailing_lists}}/listinfo/instructors">instructors</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/instructors_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/instructors/">(archives)</a>
     </td>
     <td>
       Advertisements for workshop instructors and helpers.
@@ -100,10 +100,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/mentoring_lists.software-carpentry.org">mentoring</a>
+      <a href="{{site.mailing_lists}}/listinfo/mentoring">mentoring</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/mentoring_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/mentoring/">(archives)</a>
     </td>
     <td>
       Working mailing list of the Mentoring subcommittee.
@@ -117,10 +117,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/maintainers_lists.software-carpentry.org">maintainers</a>
+      <a href="{{site.mailing_lists}}/listinfo/maintainers">maintainers</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/maintainers_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/maintainers/">(archives)</a>
     </td>
     <td>
       Working mailing list of the Lesson Development subcommittee
@@ -135,10 +135,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/r-discuss_lists.software-carpentry.org">r-discuss</a>
+      <a href="{{site.mailing_lists}}/listinfo/r-discuss">r-discuss</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/r-discuss_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/r-discuss/">(archives)</a>
     </td>
     <td>
       Disucssion of our R lesson and related matters.
@@ -155,10 +155,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/aus-nz_lists.software-carpentry.org">aus-nz</a>
+      <a href="{{site.mailing_lists}}/listinfo/aus-nz">aus-nz</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/aus-nz_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/aus-nz/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in Australia and New Zealand.
@@ -172,10 +172,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/boston_lists.software-carpentry.org">boston</a>
+      <a href="{{site.mailing_lists}}/listinfo/boston">boston</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/boston_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/boston/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Boston area.
@@ -189,10 +189,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/chicago_lists.software-carpentry.org">chicago</a>
+      <a href="{{site.mailing_lists}}/listinfo/chicago">chicago</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/chicago_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/chicago/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Chicago area.
@@ -206,10 +206,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/de_lists.software-carpentry.org">de</a>
+      <a href="{{site.mailing_lists}}/listinfo/de">de</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/de_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/de/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in Germany.
@@ -223,10 +223,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/montreal_lists.software-carpentry.org">montreal</a>
+      <a href="{{site.mailing_lists}}/listinfo/montreal">montreal</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/montreal_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/montreal/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Montreal area.
@@ -240,10 +240,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/michigan_lists.software-carpentry.org">michigan</a>
+      <a href="{{site.mailing_lists}}/listinfo/michigan">michigan</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/michigan_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/michigan/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Michigan area.
@@ -257,10 +257,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/poland_lists.software-carpentry.org">poland</a>
+      <a href="{{site.mailing_lists}}/listinfo/poland">poland</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/poland_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/poland/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in Poland.
@@ -274,10 +274,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/seattle_lists.software-carpentry.org">seattle</a>
+      <a href="{{site.mailing_lists}}/listinfo/seattle">seattle</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/seattle_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/seattle/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Seattle area.
@@ -291,10 +291,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/south-america_lists.software-carpentry.org">south-america</a>
+      <a href="{{site.mailing_lists}}/listinfo/south-america">south-america</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/south-america_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/south-america/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in South America.
@@ -308,10 +308,10 @@ an entry to
   </tr>
   <tr>
     <td>
-      <a href="{{site.mailing_lists}}/mailman/listinfo/vancouver_lists.software-carpentry.org">vancouver</a>
+      <a href="{{site.mailing_lists}}/listinfo/vancouver">vancouver</a>
     </td>
     <td>
-      <a href="{{site.mailing_lists}}/pipermail/vancouver_lists.software-carpentry.org/">(archives)</a>
+      <a href="{{site.mailing_lists}}/pipermail/vancouver/">(archives)</a>
     </td>
     <td>
       A sub-list for discussion of activities in the Vancouver area.


### PR DESCRIPTION
After moving our mailing lists to a vanilla install of mailman (no longer via cpanel) the mailing lists do not need to be named like "name_lists.software-carpentry.org", but just "name" will do.
