### PR TITLE
Remove ref to online course

### DIFF
--- a/pages/checklists_helper.html
+++ b/pages/checklists_helper.html
@@ -124,9 +124,7 @@ redirect_from:
   </li>
   <li>
     <p>
-      Let us know if you'd like to become an instructor yourself;
-      we run a <a href="{{site.baseurl}}/join/">free online training course</a>
-      for instructors.
+      Let us know if you'd like to <a href="{{site.baseurl}}/join/">become an instructor yourself</a>.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
Helper page references online instructor training course. Removed this ref as no longer active.
