### PR TITLE
Fix broken link

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -124,7 +124,7 @@ redirect_from:
     <td>Instructor Training</td>
     <td><a href="{{site.github_io_url}}/instructor-training" target="_blank" class="icon-browser" title="Instructor Training"></a></td>
     <td><a href="{{site.github_url}}/instructor-training" target="_blank" class="icon-github" title="Instructor Training"></a></td>
-    <td><a href="{{site.github_io_url}}/instructor-training/reference.html" target="_blank" class="icon-eye" title="Instructor Training"></a></td>
+    <td><a href="{{site.github_io_url}}/instructor-training/reference" target="_blank" class="icon-eye" title="Instructor Training"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#wilson_g">Greg Wilson</a>
     </td>


### PR DESCRIPTION
Link to reference material for the instructor training was broken as reported in https://github.com/swcarpentry/instructor-training/issues/217
