### PR TITLE
Remove stray quotes in Unicamp post metadata

### DIFF
--- a/_posts/2016/06/2016-06-13-unicamp-workshop.md
+++ b/_posts/2016/06/2016-06-13-unicamp-workshop.md
@@ -4,7 +4,7 @@ authors: ["Kally Chung"]
 title: "Workshop at Unicamp"
 date: 2016-06-13
 time: "00:12:01"
-category: ["Unicamp", "workshops""]
+category: ["Unicamp", "workshops"]
 ---
 A Software Carpentry workshop took place at Unicamp (State University of Campinas, Brazil) on May 23rd and 24th.
 Raniere Costa was the host and lead instructor,


### PR DESCRIPTION
The blog and RSS feed have been behaving wonky with this post, I'm guess the stray quotes in the metadata has been the cause.
