### PR TITLE
fixed route to subcom landing page

### DIFF
--- a/pages/subcom.html
+++ b/pages/subcom.html
@@ -1,6 +1,6 @@
 ---
 layout: page-fullwidth
-permalink: /join/subcom_and_tf
+permalink: /join/subcom_and_tf/
 title: Subcommittees and Task Forces
 ---
 


### PR DESCRIPTION
weird - this route bug didn't show up locally for me when doing a `make serve`, but it's super broken on the live website right now. This looks like it fixes it on my github version.
