### PR TITLE
Removing slideshows

### DIFF
--- a/_posts/2016/08/2016-08-10-ncsa-training-coordinator.md
+++ b/_posts/2016/08/2016-08-10-ncsa-training-coordinator.md
@@ -1,0 +1,26 @@
+---
+layout: post
+authors: ["Greg Wilson"]
+title: "Training Coordinator Position at NCSA"
+date: 2016-08-10
+time: "00:05:00"
+category: ["Jobs"]
+---
+
+The [Computational Science and Engineering](http://cse.illinois.edu/)
+program and the National Center for Supercomputing Applications at the
+[University of Illinois at Urbana-Champaign](http://illinois.edu/)
+seek applicants for the position of Training Coordinator.  This
+position will report jointly to the Director, CSE and the Assistant
+Director for Scientific Software and Applications at NCSA.  The
+Training Coordinator will enable cutting-edge research involving the
+use and/or development of advanced digital software and hardware
+across all disciplines by delivering, coordinating, and administrating
+training programs for students and researchers at the University of
+Illinois and area institutions, including industry.  The individual in
+this position will play a key role in the research life of the campus,
+identifying important computational and data science skills and
+technologies and demonstrating how they can be used to solve problems
+in computational science and engineering and other disciplines.
+
+For details, please see [the full job posting](http://www.ncsa.illinois.edu/about/jobs/A1600380).

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -288,27 +288,3 @@ redirect_from:
     <td>Alex Konovalov</td>
   </tr>
 </table>
-
-<h2 id="slideshows">Slideshows</h2>
-<p>
-  We have developed some presentations to explain who we are and what we do.
-  Some of these are animated with <a href="http://third-bit.com/browsercast/">Browsercast</a>,
-      and all are available in <a href="{{site.github_url}}/slideshows/">this repository</a>.
-</p>
-<table class="table table-striped">
-  <tr>
-    <td><a href="{{site.github_io_url}}/slideshows/introducing-software-carpentry/index.html">Introducing Software Carpentry</a></td>
-    <td><a href="{{site.github_io_url}}/slideshows/hosting-workshop/index.html">Hosting a Workshop</a></td>
-    <td><a href="{{site.github_io_url}}/slideshows/best-practices/index.html">Best Practices in Scientific Computing</a></td>
-  </tr>
-  <tr>
-    <td><a href="{{site.github_io_url}}/slideshows/lessons-learned/index.html">Software Carpentry: Lessons Learned</a></td>
-    <td><a href="{{site.github_io_url}}/slideshows/teaching-tips/index.html">Teaching Tips</a></td>
-    <td><a href="{{site.github_io_url}}/slideshows/creating-website/index.html">Creating a Workshop Website</a></td>
-  </tr>
-  <tr>
-    <td><a href="{{site.github_io_url}}/slideshows/creating-lesson/index.html">Creating a Lesson</a></td>
-    <td>&nbsp;</td>
-    <td>&nbsp;</td>
-  </tr>
-</table>


### PR DESCRIPTION
Don't know why the extraneous commits (NCSA job, etc.) are showing up in this PR - I forked it directly off gh-pages - but this removes links to the slideshows from the lessons page until we find someone to update and maintain them (they're all badly out of date).
