### PR TITLE
Fixing up some blog posts.

### DIFF
--- a/_posts/2016/09/2016-09-10-community-service-award.md
+++ b/_posts/2016/09/2016-09-10-community-service-award.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 authors: ["Greg Wilson"]
-title: "Communitiy Service Awards"
+title: "Community Service Awards"
 date: 2016-09-10
 time: "08:00:00"
 category: ["Community", "Software Carpentry Foundation"]

--- a/_posts/2016/09/2016-09-20-federal-reserve-board.md
+++ b/_posts/2016/09/2016-09-20-federal-reserve-board.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 authors: ["Chris Hamm"]
-title: "The Board"
+title: "Teaching at the Board"
 date: 2016-09-20
 time: "00:08:00"
 category: ["Teaching"]
@@ -31,6 +31,7 @@ It is important for potential leaners to recognize that we teach basic computer 
 Sticky notes (the learners write something that we could improve on and something that worked well for them) from my lessons are below:
 
 #### Intro to R
+
 *Worked well:*
 
 - Thanks for noticing & adjusting to the level of the class: interested in for tomorrow: call stack, tidyr, split-apply-combine, vectorization

--- a/_posts/2016/09/2016-09-28-attendance-nz.md
+++ b/_posts/2016/09/2016-09-28-attendance-nz.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 authors: ["Tom Kelly", "Mik Black", "Sung Bae", "Wolfgang Hayek", "Aleksandra Pawlik"]
-title: "Software Carpentry workshop attendance: a New Zealand perspective"
+title: "Software Carpentry Workshop Attendance: a New Zealand Perspective"
 date: 2016-09-28
 time: "00:00:01"
 category: ["Attendance", "Workshops"]


### PR DESCRIPTION
1. Typo in title of community service award announcement.
2. Chris Hamm's post wasn't showing up because the filename extension was `.m` rather than `.md`.
