### PR TITLE
Blog post about GAP lesson

### DIFF
--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -137,7 +137,7 @@ The lesson on GAP can be seen [here](http://alex-konovalov.github.io/gap-lesson/
 and it has been published via Zenodo [here](http://doi.org/10.5281/zenodo.167362).
 So far I am only aware that it has been taught twice (by myself) at two annual
 [CoDiMa training schools in computational discrete mathematics](http://www.codima.ac.uk/schools/).
-I can surely teach it lesson myself, but is it written clearly enough
+I can surely teach it myself, but is it written clearly enough
 to be taught by others? Is it possible for the reader to follow it for
 self-studying? Is there any introductory material missing, or is there an
 interest in having more advanced lesson(s) on some other aspects of

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -7,8 +7,9 @@ time: "15:00:00"
 category: ["Lessons"]
 ---
 
-This is a blog post about the Software Carpentry lesson
-["Programming with GAP"](http://alex-konovalov.github.io/gap-lesson/).
+ Software Carpentry is more than just a set of workshops and lessons. It is
+ also a way to develop lessons, one that we have used successfully to create
+ a lesson on [Programming with GAP](http://alex-konovalov.github.io/gap-lesson/).
 
 [GAP](http://www.gap-system.org/) is an open source system for discrete
 computational algebra. It provides a programming language with the same name;

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -137,7 +137,7 @@ The lesson on GAP can be seen [here](http://alex-konovalov.github.io/gap-lesson/
 and it has been published via Zenodo [here](http://doi.org/10.5281/zenodo.167362).
 So far I am only aware that it has been taught twice (by myself) at two annual
 [CoDiMa training schools in computational discrete mathematics](http://www.codima.ac.uk/schools/).
-What next? I can surely teach it lesson myself, but is it written clearly enough
+I can surely teach it lesson myself, but is it written clearly enough
 to be taught by others? Is it possible for the reader to follow it for
 self-studying? Is there any introductory material missing, or is there an
 interest in having more advanced lesson(s) on some other aspects of

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -7,6 +7,9 @@ time: "15:00:00"
 category: ["Lessons"]
 ---
 
+This is a blog post about the Software Carpentry lesson
+["Programming with GAP"](http://alex-konovalov.github.io/gap-lesson/).
+
 [GAP](http://www.gap-system.org/) is an open source system for discrete
 computational algebra. It provides a programming language with the same name;
 thousands of functions implementing various algebraic algorithms; and data

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -17,7 +17,7 @@ on GAP homepage [here](http://www.gap-system.org/Doc/doc.html).
 
 Throughout the history of GAP, its development has been supported by a
 number of [grants](http://www.gap-system.org/Contacts/funding.html), one
-of these being the EPSRC project EP/M022641 []"CoDiMa (CCP in the area of
+of these being the EPSRC project EP/M022641 ["CoDiMa (CCP in the area of
 Computational Discrete Mathematics"](http://www.codima.ac.uk/). This is
 a community-building project centred on [GAP](http://www.gap-system.org/)
 and another open source mathematical software system,
@@ -30,17 +30,17 @@ version control and task automation, continued with introductions to GAP
 and SageMath systems, and followed by the series of lectures and exercise
 classes on a selection of topics in computational discrete mathematics.
 
-This naturally leads to the idea of establishing a Software Carpentry lesson
+This naturally led to the idea of establishing a Software Carpentry lesson
 on programming with GAP. I started to develop it in 2015 for our
 [first training school in Manchester](http://www.codima.ac.uk/school2015/).
 I took inspiration from the core Software Carpentry lessons, in particular
-on UNIX shell, Python and R.
+from those on UNIX shell, Python and R.
 
 Since I have never been at any of the Software Carpentry workshops before and
-had not yet completed instructor training, it was extremely beneficial for me
-to come as a helper to the first ever
+had not yet completed instructor training at that point (it is currently in
+progress), it was extremely beneficial for me to come as a helper to the first ever
 [Software Carpentry workshop in St Andrews](https://lmwake.github.io/2015-06-18-StAndrews/)
-in June 2015 and obtain an insight into the Software Carpentry teaching
+in June 2015, and obtain an insight into the Software Carpentry teaching
 methodology.
 
 A good Software Carpentry lesson should have a central story which goes
@@ -57,61 +57,83 @@ package, are not so obvious for the beginners, and I have made an attempt
 to create a lesson which will show the direction in which their skills should
 be developing, and also to cover the importance of testing their code.
 
-I started from picking up a research-like problem which can be the central
-one for the lesson and which may nicely expose all needed techniques and
-mindsets. A good candidate was the problem of calculating an average order of
-an element of the group, which once I've seen being used by Steve Linton to
-quickly demonstrate some GAP features to a general scientific audience.
-After I have used it for a talk in Newcastle in May 2015 (see the blog post
+I started from picking up a research-like problem which may nicely expose
+all needed techniques and explain the mindset required to deal with it.
+A good candidate was the problem of calculating an average order of an element
+of the group, which once I've seen being used by Steve Linton to quickly
+demonstrate some GAP features to a general scientific audience. I have tried to
+expand this problem in my talk in Newcastle in May 2015 (see the blog post
 [here](http://www.codima.ac.uk/2015/07/01/average-order-of-group-elements-a-demo-of-test-driven-development-in-gap/),
-the choice was made.
+an thus the choice has been made.
 
-The problem of determining an average order of the element of the group
-is enough simple problem to not to distract learners too much from the
-intended learning outcomes of the lesson, and undergraduate course in
-algebra is sufficient prerequisite to understanding the lesson. Those
-learners who are not familiar with the group theory, should still be able
-to follow the lesson just by assuming that there is a mathematical structure
-called group, and we need to find an average value of a certain numerical
-parameter associated with each of its elements. On the other hand, those
-with sufficient theoretical background will hopefully enjoy seeing how the
-initial naive implementation is being refined several times during the
-lesson, and how theoretical insights are give much more advances than minor
-code optimisations or just getting more cores.
+Indeed, the problem of determining an average order of the element of the group
+is simple enough to not to distract learners too much from the intended learning
+outcomes of the lesson. An undergraduate algebra course is sufficient for its
+understanding. Moreover, those not familiar with the group theory still should
+be able to follow the lesson just by grasping the idea that there is a
+mathematical structure called group, and we need to find an average value of a
+certain numerical parameter associated with each of its elements. On the other
+hand, those with sufficient theoretical background will hopefully enjoy seeing
+how the initial naive implementation is being refined several times during the
+lesson, and how theoretical insights are giving much more significant advances
+than minor code optimisations or just getting more cores.
 
-One particular topic that usually escapes beginners' attention is testing,
+The lesson starts with formulating the problem of finding examples of groups
+such that the average order of their element is an integer. It first explains
+how to work with the GAP command prompt, demonstrates some basic language
+constructions and explains how to find necessary information in the GAP help system.
+At this point using the command line we establish a rough prototype of the code to
+compute an average order of a group, and tried several examples, none of them
+yielding an integer.
+
+Next, it discusses that the command line usage is good only for rapid
+prototyping, and explains how to create GAP functions, place them into
+a file, and read that file into GAP. After that, the initial implementation is
+used to create a regression test: GAP runs it by comparing the actual output
+with the reference output, and will fail the test in case of any discrepancies.
+Testing the code is a topic that usually escapes beginners' attention,
 and I am really excited about managing to cover it as a part of the introductory
 GAP lesson. I explain the "make it right, than make it fast" paradigm, and
-explain how to create and run regression tests in GAP after the first naive
-implementation is available. To demonstrate test failures, I deliberately mix
-up function names to break the test, and it's a real pleasure when someone
-from the audience points it out before I even manage to re-run the test and
-show how it fails.
+show how to create and run regression tests in GAP after the first naive
+implementation is available. To demonstrate test failures, I deliberately mixed
+up function names to break the test, and it was a real pleasure when the
+audience pointed that out before I even managed to re-run the test and demonstrate
+that it failed.
 
-TODO: Describe better how the structure of the lesson looks like
-and how the problem of finding the group with an integer average order
-of an element fits into every episode:
+Having the improved and tested implementation, we start systematic search for
+finite groups with an integer average order of an element using the
+[GAP Small Groups Library](http://www.gap-system.org/Packages/sgl.html) which
+contains, among others, all 423 164 062 groups of order at most 2000 except 1024.
+At the same time, the lesson introduces modular programming and shows how one
+can design a system of functions to perform the search in a way that one could re-use
+most of the code and only develop a new function to test a single group to deal
+with another search problem. Then the first interesting example
+(a group of order 105 such that the average order of its elements is 17) is
+discovered! The next obstacle is to check all 56092 groups of order 256, however,
+a short theoretical observation shows that we can exclude groups of prime power
+order from the search, as they will never have an integer average order of an
+element. After modifying the code to skip such orders, the search continues, and
+then another example (a group of order 357) is found. Discovering another known
+group with this property is left as one of the exercises.
 
-* First session with GAP - Working with the GAP command line
-* Some more GAP objects	- Further examples of immediate and positional objects and operations with them
-* Functions in GAP - Functions as a way of code re-use
-* Using regression tests - Test-driven development
-* Small groups search	- Modular programming: putting functions together. How to check some conjecture for all groups of a given order?
-* Attributes and Methods - How to record information in GAP objects
+The lesson finishes with explaining how the knowledge about the object can be
+stored in it. For example, once the average order of an element of a group is
+calculated and stored in the group, it can be next time retrieved at zero cost,
+avoiding redundant calculations.
 
-GAP lesson taught twice so far and published on Zenodo
-[here](http://doi.org/10.5281/zenodo.167362).
-What next? I can teach my lesson myself, but is it written clearly enough
+The lesson on GAP can be seen [here](http://alex-konovalov.github.io/gap-lesson/),
+and it has been published via Zenodo [here](http://doi.org/10.5281/zenodo.167362).
+So far I am only aware that it has been taught twice (by myself) at two annual
+[CoDiMa training schools in computational discrete mathematics](http://www.codima.ac.uk/schools/).
+What next? I can surely teach it lesson myself, but is it written clearly enough
 to be taught by others? Is it possible for the reader to follow it for
 self-study? Is there any introductory material missing, or is there an
-interest in having more advanced lesson(s) on some (which?) aspects of
-the system? If you would like to contribute to its further development,
+interest in having more advanced lesson(s) on some other aspects of
+the GAP system? If you would like to contribute to its further development,
 issues and pull requests to its repository on
 [GitHub](https://github.com/alex-konovalov/gap-lesson) are most welcome!
-
-We are now starting to develop a
-[lesson on SageMath](https://github.com/alex-konovalov/sage-lesson).
-We invite collaborators: please watch the repository if you’re
-interested in following along, and add a comment to
-[this issue](https://github.com/alex-konovalov/sage-lesson/issues/1)
+Also, we invite collaborators interested in developing a lesson on
+[SageMath](http://www.sagemath.org/): please look at
+[this repository](https://github.com/alex-konovalov/sage-lesson) and
+add a comment to [this issue](https://github.com/alex-konovalov/sage-lesson/issues/1)
 if you’re interested in contributing.

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -11,7 +11,7 @@ category: ["Lessons"]
 computational algebra. It provides a programming language with the same name;
 thousands of functions implementing various algebraic algorithms; and data
 libraries containing extensive collections of algebraic objects. GAP
-distribution included its detailed documentation, and more materials on
+distribution includes its detailed documentation; even more materials on
 learning GAP and on using it in teaching a variety of courses are available
 on GAP homepage [here](http://www.gap-system.org/Doc/doc.html).
 
@@ -21,7 +21,7 @@ of these being the EPSRC project EP/M022641 ["CoDiMa (CCP in the area of
 Computational Discrete Mathematics"](http://www.codima.ac.uk/). This is
 a community-building project centred on [GAP](http://www.gap-system.org/)
 and another open source mathematical software system,
-[SageMath](http://www.sagemath.org/). Its activities include [annual training
+[SageMath](http://www.sagemath.org/). CoDiMa activities include [annual training
 schools in computational discrete mathematics](http://www.codima.ac.uk/schools/),
 which are primarily intended for PhD students and researchers from UK
 institutions. A typical school starts with the Software Carpentry workshop
@@ -33,9 +33,6 @@ classes on a selection of topics in computational discrete mathematics.
 This naturally led to the idea of establishing a Software Carpentry lesson
 on programming with GAP. I started to develop it in 2015 for our
 [first training school in Manchester](http://www.codima.ac.uk/school2015/).
-I took inspiration from the core Software Carpentry lessons, in particular
-from those on UNIX shell, Python and R.
-
 Since I have never been at any of the Software Carpentry workshops before and
 had not yet completed instructor training at that point (it is currently in
 progress), it was extremely beneficial for me to come as a helper to the first ever
@@ -43,14 +40,16 @@ progress), it was extremely beneficial for me to come as a helper to the first e
 in June 2015, and obtain an insight into the Software Carpentry teaching
 methodology.
 
-A good Software Carpentry lesson should have a central story which goes
-through almost every its episode. I have imagined a common situation: a
+I took inspiration from the core Software Carpentry lessons,
+in particular from those on UNIX shell, Python and R.
+All of them have a central story which goes through almost every episode.
+For the GAP lesson, I have imagined a common situation: a
 research student with no prior experience of working with GAP (and perhaps
 little or no experience with programming at all) is facing a task to find
 a way in the huge library of GAP functions in order to study some research
 problem. Along this way, they start to work with GAP command line to explore
-algebraic objects interactively; then start to use the GAP language to write
-some simple scripts; then start to create own functions. More advanced topics
+algebraic objects interactively; then use the GAP language to write
+some simple scripts; then create own functions. More advanced topics
 such as, for example, extending GAP with new methods for existing types of
 objects, or even new objects, or organising your code in the form of a GAP
 package, are not so obvious for the beginners, and I have made an attempt
@@ -63,7 +62,7 @@ A good candidate was the problem of calculating an average order of an element
 of the group, which once I've seen being used by Steve Linton to quickly
 demonstrate some GAP features to a general scientific audience. I have tried to
 expand this problem in my talk in Newcastle in May 2015 (see the blog post
-[here](http://www.codima.ac.uk/2015/07/01/average-order-of-group-elements-a-demo-of-test-driven-development-in-gap/),
+[here](http://www.codima.ac.uk/2015/07/01/average-order-of-group-elements-a-demo-of-test-driven-development-in-gap/)),
 an thus the choice has been made.
 
 Indeed, the problem of determining an average order of the element of the group
@@ -72,7 +71,7 @@ outcomes of the lesson. An undergraduate algebra course is sufficient for its
 understanding. Moreover, those not familiar with the group theory still should
 be able to follow the lesson just by grasping the idea that there is a
 mathematical structure called group, and we need to find an average value of a
-certain numerical parameter associated with each of its elements. On the other
+certain numerical parameter associated with each element of it. On the other
 hand, those with sufficient theoretical background will hopefully enjoy seeing
 how the initial naive implementation is being refined several times during the
 lesson, and how theoretical insights are giving much more significant advances
@@ -121,13 +120,23 @@ stored in it. For example, once the average order of an element of a group is
 calculated and stored in the group, it can be next time retrieved at zero cost,
 avoiding redundant calculations.
 
+Of course, it is not possible to cover everything in a several hours long
+course, but it fits really well into the week-long CoDiMa training school like
+[this](http://www.codima.ac.uk/school2016/). It prepares the audience to hear
+about more advanced topics during the rest of the week: debugging and profiling;
+advanced GAP programming; GAP type system; distributed parallel calculations;
+examples of some algorithms and their implementations, etc. Also, staying for
+the whole week of the school, everyone has plenty of opportunities to ask
+further questions to instructors.
+
+What next?
 The lesson on GAP can be seen [here](http://alex-konovalov.github.io/gap-lesson/),
 and it has been published via Zenodo [here](http://doi.org/10.5281/zenodo.167362).
 So far I am only aware that it has been taught twice (by myself) at two annual
 [CoDiMa training schools in computational discrete mathematics](http://www.codima.ac.uk/schools/).
 What next? I can surely teach it lesson myself, but is it written clearly enough
 to be taught by others? Is it possible for the reader to follow it for
-self-study? Is there any introductory material missing, or is there an
+self-studying? Is there any introductory material missing, or is there an
 interest in having more advanced lesson(s) on some other aspects of
 the GAP system? If you would like to contribute to its further development,
 issues and pull requests to its repository on

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -1,0 +1,117 @@
+---
+layout: post
+authors: ["Alexander Konovalov"]
+title: "Programming with GAP"
+date: 2016-11-18
+time: "15:00:00"
+category: ["Lessons"]
+---
+
+[GAP](http://www.gap-system.org/) is an open source system for discrete
+computational algebra. It provides a programming language with the same name;
+thousands of functions implementing various algebraic algorithms; and data
+libraries containing extensive collections of algebraic objects. GAP
+distribution included its detailed documentation, and more materials on
+learning GAP and on using it in teaching a variety of courses are available
+on GAP homepage [here](http://www.gap-system.org/Doc/doc.html).
+
+Throughout the history of GAP, its development has been supported by a
+number of [grants](http://www.gap-system.org/Contacts/funding.html), one
+of these being the EPSRC project EP/M022641 []"CoDiMa (CCP in the area of
+Computational Discrete Mathematics"](http://www.codima.ac.uk/). This is
+a community-building project centred on [GAP](http://www.gap-system.org/)
+and another open source mathematical software system,
+[SageMath](http://www.sagemath.org/). Its activities include [annual training
+schools in computational discrete mathematics](http://www.codima.ac.uk/schools/),
+which are primarily intended for PhD students and researchers from UK
+institutions. A typical school starts with the Software Carpentry workshop
+covering basic concepts and tools, such as working with the command line,
+version control and task automation, continued with introductions to GAP
+and SageMath systems, and followed by the series of lectures and exercise
+classes on a selection of topics in computational discrete mathematics.
+
+This naturally leads to the idea of establishing a Software Carpentry lesson
+on programming with GAP. I started to develop it in 2015 for our
+[first training school in Manchester](http://www.codima.ac.uk/school2015/).
+I took inspiration from the core Software Carpentry lessons, in particular
+on UNIX shell, Python and R.
+
+Since I have never been at any of the Software Carpentry workshops before and
+had not yet completed instructor training, it was extremely beneficial for me
+to come as a helper to the first ever
+[Software Carpentry workshop in St Andrews](https://lmwake.github.io/2015-06-18-StAndrews/)
+in June 2015 and obtain an insight into the Software Carpentry teaching
+methodology.
+
+A good Software Carpentry lesson should have a central story which goes
+through almost every its episode. I have imagined a common situation: a
+research student with no prior experience of working with GAP (and perhaps
+little or no experience with programming at all) is facing a task to find
+a way in the huge library of GAP functions in order to study some research
+problem. Along this way, they start to work with GAP command line to explore
+algebraic objects interactively; then start to use the GAP language to write
+some simple scripts; then start to create own functions. More advanced topics
+such as, for example, extending GAP with new methods for existing types of
+objects, or even new objects, or organising your code in the form of a GAP
+package, are not so obvious for the beginners, and I have made an attempt
+to create a lesson which will show the direction in which their skills should
+be developing, and also to cover the importance of testing their code.
+
+I started from picking up a research-like problem which can be the central
+one for the lesson and which may nicely expose all needed techniques and
+mindsets. A good candidate was the problem of calculating an average order of
+an element of the group, which once I've seen being used by Steve Linton to
+quickly demonstrate some GAP features to a general scientific audience.
+After I have used it for a talk in Newcastle in May 2015 (see the blog post
+[here](http://www.codima.ac.uk/2015/07/01/average-order-of-group-elements-a-demo-of-test-driven-development-in-gap/),
+the choice was made.
+
+The problem of determining an average order of the element of the group
+is enough simple problem to not to distract learners too much from the
+intended learning outcomes of the lesson, and undergraduate course in
+algebra is sufficient prerequisite to understanding the lesson. Those
+learners who are not familiar with the group theory, should still be able
+to follow the lesson just by assuming that there is a mathematical structure
+called group, and we need to find an average value of a certain numerical
+parameter associated with each of its elements. On the other hand, those
+with sufficient theoretical background will hopefully enjoy seeing how the
+initial naive implementation is being refined several times during the
+lesson, and how theoretical insights are give much more advances than minor
+code optimisations or just getting more cores.
+
+One particular topic that usually escapes beginners' attention is testing,
+and I am really excited about managing to cover it as a part of the introductory
+GAP lesson. I explain the "make it right, than make it fast" paradigm, and
+explain how to create and run regression tests in GAP after the first naive
+implementation is available. To demonstrate test failures, I deliberately mix
+up function names to break the test, and it's a real pleasure when someone
+from the audience points it out before I even manage to re-run the test and
+show how it fails.
+
+TODO: Describe better how the structure of the lesson looks like
+and how the problem of finding the group with an integer average order
+of an element fits into every episode:
+
+* First session with GAP - Working with the GAP command line
+* Some more GAP objects	- Further examples of immediate and positional objects and operations with them
+* Functions in GAP - Functions as a way of code re-use
+* Using regression tests - Test-driven development
+* Small groups search	- Modular programming: putting functions together. How to check some conjecture for all groups of a given order?
+* Attributes and Methods - How to record information in GAP objects
+
+GAP lesson taught twice so far and published on Zenodo
+[here](http://doi.org/10.5281/zenodo.167362).
+What next? I can teach my lesson myself, but is it written clearly enough
+to be taught by others? Is it possible for the reader to follow it for
+self-study? Is there any introductory material missing, or is there an
+interest in having more advanced lesson(s) on some (which?) aspects of
+the system? If you would like to contribute to its further development,
+issues and pull requests to its repository on
+[GitHub](https://github.com/alex-konovalov/gap-lesson) are most welcome!
+
+We are now starting to develop a
+[lesson on SageMath](https://github.com/alex-konovalov/sage-lesson).
+We invite collaborators: please watch the repository if you’re
+interested in following along, and add a comment to
+[this issue](https://github.com/alex-konovalov/sage-lesson/issues/1)
+if you’re interested in contributing.

--- a/_posts/2016/11/2016-11-21-gap-lesson.md
+++ b/_posts/2016/11/2016-11-21-gap-lesson.md
@@ -67,62 +67,18 @@ of the group, which once I've seen being used by Steve Linton to quickly
 demonstrate some GAP features to a general scientific audience. I have tried to
 expand this problem in my talk in Newcastle in May 2015 (see the blog post
 [here](http://www.codima.ac.uk/2015/07/01/average-order-of-group-elements-a-demo-of-test-driven-development-in-gap/)),
-an thus the choice has been made.
+and thus the choice has been made.
 
-Indeed, the problem of determining an average order of the element of the group
-is simple enough to not to distract learners too much from the intended learning
-outcomes of the lesson. An undergraduate algebra course is sufficient for its
-understanding. Moreover, those not familiar with the group theory still should
-be able to follow the lesson just by grasping the idea that there is a
-mathematical structure called group, and we need to find an average value of a
-certain numerical parameter associated with each element of it. On the other
-hand, those with sufficient theoretical background will hopefully enjoy seeing
-how the initial naive implementation is being refined several times during the
-lesson, and how theoretical insights are giving much more significant advances
-than minor code optimisations or just getting more cores.
-
-The lesson starts with formulating the problem of finding examples of groups
-such that the average order of their element is an integer. It first explains
-how to work with the GAP command prompt, demonstrates some basic language
-constructions and explains how to find necessary information in the GAP help system.
-At this point using the command line we establish a rough prototype of the code to
-compute an average order of a group, and tried several examples, none of them
-yielding an integer.
-
-Next, it discusses that the command line usage is good only for rapid
-prototyping, and explains how to create GAP functions, place them into
-a file, and read that file into GAP. After that, the initial implementation is
-used to create a regression test: GAP runs it by comparing the actual output
-with the reference output, and will fail the test in case of any discrepancies.
-Testing the code is a topic that usually escapes beginners' attention,
-and I am really excited about managing to cover it as a part of the introductory
-GAP lesson. I explain the "make it right, than make it fast" paradigm, and
-show how to create and run regression tests in GAP after the first naive
-implementation is available. To demonstrate test failures, I deliberately mixed
-up function names to break the test, and it was a real pleasure when the
-audience pointed that out before I even managed to re-run the test and demonstrate
-that it failed.
-
-Having the improved and tested implementation, we start systematic search for
-finite groups with an integer average order of an element using the
-[GAP Small Groups Library](http://www.gap-system.org/Packages/sgl.html) which
-contains, among others, all 423 164 062 groups of order at most 2000 except 1024.
-At the same time, the lesson introduces modular programming and shows how one
-can design a system of functions to perform the search in a way that one could re-use
-most of the code and only develop a new function to test a single group to deal
-with another search problem. Then the first interesting example
-(a group of order 105 such that the average order of its elements is 17) is
-discovered! The next obstacle is to check all 56092 groups of order 256, however,
-a short theoretical observation shows that we can exclude groups of prime power
-order from the search, as they will never have an integer average order of an
-element. After modifying the code to skip such orders, the search continues, and
-then another example (a group of order 357) is found. Discovering another known
-group with this property is left as one of the exercises.
-
-The lesson finishes with explaining how the knowledge about the object can be
-stored in it. For example, once the average order of an element of a group is
-calculated and stored in the group, it can be next time retrieved at zero cost,
-avoiding redundant calculations.
+The resulting lesson leads the learner along the path from working in the GAP
+command line and exploring algebraic objects interactively to saving the GAP
+code into files, creating functions and regression tests, and further to
+performing comprehensive search using one of the data libraries supplied with
+GAP, and extending the system by adding new attributes. On this path, the
+learner will became familiar with basic constructions of the GAP programming
+language; ways to find necessary information in the GAP system; and
+good design practices to organise GAP code into complex programs
+(for a more detailed lesson overview, see my blog post
+[here](http://blogs.cs.st-andrews.ac.uk/alexk/2016/11/22/publishing-software-carpentry-lesson-on-gap/)).
 
 Of course, it is not possible to cover everything in a several hours long
 course, but it fits really well into the week-long CoDiMa training school like


### PR DESCRIPTION
This is a blog post on the GAP Software Carpentry lesson (listed as "contributed" at http://software-carpentry.org/lessons/): 

- lesson itself: http://alex-konovalov.github.io/gap-lesson/
- published via Zenodo: http://doi.org/10.5281/zenodo.167362
- lesson repository: https://github.com/alex-konovalov/gap-lesson

It happened that in the process of writing the blog post became bigger than I initially intended - please let me know if you'd like any revisions.
