### PR TITLE
_posts: Consolidate categories

### DIFF
--- a/_posts/2009/09/2009-09-22-grant-proposal.html
+++ b/_posts/2009/09/2009-09-22-grant-proposal.html
@@ -4,7 +4,7 @@ date: 2009-09-22
 time: "09:00:00"
 authors: ["Greg Wilson"]
 title: Grant Proposal
-category: ["Support"]
+category: ["Funding"]
 ---
 <p>Rebuilding the Software Carpentry course is too big to do in anyone's spare time, so I've submitted a small funding application (included below). If you know any venues that might welcome a similar proposal, I'd be grateful for pointers.</p>
 <hr />

--- a/_posts/2009/12/2009-12-19-nsf-programs.html
+++ b/_posts/2009/12/2009-12-19-nsf-programs.html
@@ -4,7 +4,7 @@ date: 2009-12-19
 time: "09:00:00"
 authors: ["Greg Wilson"]
 title: NSF Programs
-category: ["Support"]
+category: ["Funding"]
 ---
 <p>I'd be interested in hearing from anyone who has enough direct experience of the following NSF programs to know whether they might be willing to support Software Carpentry:</p>
 <ol>

--- a/_posts/2010/02/2010-02-25-eighty-per-cent.html
+++ b/_posts/2010/02/2010-02-25-eighty-per-cent.html
@@ -4,6 +4,6 @@ date: 2010-02-25
 time: "09:00:00"
 authors: ["Greg Wilson"]
 title: Eighty Per Cent!
-category: ["Support"]
+category: ["Funding"]
 ---
 <p>As of this morning, I have signed commitments for 4/5 of the money I need to spend a year working full-time on updating the Software Carpentry course. If you, or someone you know, would like to help me help scientists be more productive, please <a href="mailto:{{site.contact}}">get in touch</a>: I have only 64 days in which to find the $30K I still need.</p>

--- a/_posts/2011/01/2011-01-14-our-funding-pitch.html
+++ b/_posts/2011/01/2011-01-14-our-funding-pitch.html
@@ -4,7 +4,7 @@ date: 2011-01-14
 time: "09:00:00"
 authors: ["Greg Wilson"]
 title: Our Funding Pitch
-category: ["Sponsors"]
+category: ["Funding"]
 ---
 <p>A couple of people have recently asked, "How do you go about asking for money?" Applying for grants from NSERC, the NSF, and other agencies is something they understand (though it never actually worked for me), but cold-calling people, or emailing them out of the blue, isn't something most academics have ever done.</p>
 <p>I'm <a href="{{site.baseurl}}/blog/2011/01/funding-a-plea-for-contacts.html">now doing another round of this</a>, and since this is supposed to be an open-everything project, I've posted the short pitch I use as a starting point when approaching someone new. I hope you find it useful, and of course, feedback is always welcome.</p>

--- a/_posts/2013/09/2013-09-24-ssi-fellowship-fund.html
+++ b/_posts/2013/09/2013-09-24-ssi-fellowship-fund.html
@@ -4,7 +4,7 @@ authors: ["Aleksandra Pawlik"]
 title: "SSI Fellowship Programme 2014"
 date: 2013-09-24
 time: "09:00:00"
-category: ["Community", "Announcements", "Support"]
+category: ["Community", "Announcements", "Funding"]
 ---
 <p>The Software Sustainability Institute is offering Fellowships with &#163;3000 funding for travel, collaboration and running events, including Software Carpentry bootcamps. The Fellowship Programme 2014 recognises outstanding UK-based researchers who use and develop software. <a href=" http://www.software.ac.uk/fellowship-programme/fellowship-programme-application-form">Online applications </a> are open until  September 27th, 2013 at 5:00 PM BST.</p>
 <!--more-->

--- a/_posts/2014/06/2014-06-22-translating-software-carpentry-into-spanish.html
+++ b/_posts/2014/06/2014-06-22-translating-software-carpentry-into-spanish.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Translating Software Carpentry into Spanish"
 date: 2014-06-22
 time: "07:00:00"
-category: ["Translations"]
+category: ["Translation"]
 ---
 <p>
   We are very pleased to announce that a group of volunteers have begun

--- a/_posts/2014/07/2014-07-08-translating-software-carpentry-into-portuguese.html
+++ b/_posts/2014/07/2014-07-08-translating-software-carpentry-into-portuguese.html
@@ -4,7 +4,7 @@ authors: ["Raniere Silva"]
 title: "Translating Software Carpentry into Portuguese"
 date: 2014-07-08
 time: "18:35:05"
-category: ["Translations"]
+category: ["Translation"]
 ---
 <p>
   We are very pleased to announce that we will run a half day

--- a/_posts/2014/11/2014-11-15-lessons-repo-split-and-translations.html
+++ b/_posts/2014/11/2014-11-15-lessons-repo-split-and-translations.html
@@ -4,7 +4,7 @@ authors: ["Gabriel A. Devenyi"]
 title: "Lessons, the Repository Split, and Translations"
 date: 2014-11-15
 time: "13:00:00"
-category: ["Tooling", "Translations"]
+category: ["Tooling", "Translation"]
 ---
 <p>
   Keeping on the roll of the posts about the

--- a/_posts/2015/06/2015-06-21-recycling-training-course-material.html
+++ b/_posts/2015/06/2015-06-21-recycling-training-course-material.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Recycling Training Course Material"
 date: 2015-06-21
 time: "13:00:00"
-category: ["Training"]
+category: ["Instructor Training"]
 ---
 <p>
   Over the past two years,

--- a/_posts/2016/04/2016-04-20-tips-tricks-live-coding.md
+++ b/_posts/2016/04/2016-04-20-tips-tricks-live-coding.md
@@ -4,7 +4,7 @@ authors: ["Lex Nederbragt"]
 title: "10 tips and tricks for instructing and teaching by means of live coding"
 date: 2016-04-20
 time: "00:00:00"
-category: ["education", "instructor-training"]
+category: ["Education", "Instructor Training"]
 ---
 
 One of the key teaching practices used at Software and Data Carpentry workshops is 'live coding': instructors don't use slides, but work through the lesson material, typing in the code or instructions, with the workshop participants following along. Learning how to teach using live-coding is best done in practice, with feedback from peers (this is why it is included in [instructor training]({{site.github_io_url}}/instructor-training/08-practices.html)). Nonetheless, this post lists ten tips and tricks to help you get started.

--- a/_posts/2016/06/2016-06-13-unicamp-workshop.md
+++ b/_posts/2016/06/2016-06-13-unicamp-workshop.md
@@ -4,7 +4,7 @@ authors: ["Kally Chung"]
 title: "Workshop at Unicamp"
 date: 2016-06-13
 time: "00:12:01"
-category: ["Unicamp", "workshops"]
+category: ["Unicamp", "Workshops"]
 ---
 A Software Carpentry workshop took place at Unicamp (State University of Campinas, Brazil) on May 23rd and 24th.
 Raniere Costa was the host and lead instructor,

--- a/_posts/2016/06/2016-06-22-LCworkshop.md
+++ b/_posts/2016/06/2016-06-22-LCworkshop.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Teaching Library Carpentry"
 date: 2016-06-22
 time: "00:00:01"
-category: ["workshops", "Library Carpentry"]
+category: ["Workshops", "Library Carpentry"]
 ---
 ## Teaching Library Carpentry 
 

--- a/_posts/2016/06/2016-06-22-WorkshopSurvey.md
+++ b/_posts/2016/06/2016-06-22-WorkshopSurvey.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Workshop Satisfaction Survey"
 date: 2016-06-22
 time: "00:00:01"
-category: ["surveys", "workshops"]
+category: ["Surveys", "Workshops"]
 ---
 ## Calling all Software Carpentry workshop attendees! 
 

--- a/_posts/2016/06/2016-06-31-brazil.md
+++ b/_posts/2016/06/2016-06-31-brazil.md
@@ -4,7 +4,7 @@ authors: ["Raniere Silva"]
 title: "Three workshops in Brazil"
 date: 2016-06-31
 time: "10:00:00"
-category: ["workshops"]
+category: ["Workshops"]
 ---
 In Brazil, like in many other countries that we are starting to run workshops,
 there are many open questions that we need to answer such as

--- a/_posts/2016/07/2016-07-27-change-careers.md
+++ b/_posts/2016/07/2016-07-27-change-careers.md
@@ -4,7 +4,7 @@ authors: ["Marco Fahmi"]
 title: "How Software Carpentry can help you switch careers"
 date: 2016-07-27
 time: "00:00:01"
-category: ["Training", "Careers"]
+category: ["Instructor Training", "Careers"]
 ---
 
 You've heard how Software Carpentry is important not only to get your research done but also to make it better and thus

--- a/_posts/2016/09/2016-09-01-election-procedures.md
+++ b/_posts/2016/09/2016-09-01-election-procedures.md
@@ -4,7 +4,7 @@ authors: ["Kate Hertweck"]
 title: "Election Announcement: Amending Steering Committee election procedures"
 date: 2016-09-01
 time: "00:10:00"
-category: ["steering committee"]
+category: ["Steering Committee"]
 ---
 
 The Steering Committee will be holding a special election on October 10-14

--- a/_posts/2016/09/2016-09-13-first-SWC-impressions.md
+++ b/_posts/2016/09/2016-09-13-first-SWC-impressions.md
@@ -4,7 +4,7 @@ authors: ["Leo Browning"]
 title: "SWC: First Impressions"
 date: 2016-09-28
 time: "12:00:00"
-category: ["Workshop", "New Zealand"]
+category: ["Workshops", "New Zealand"]
 ---
 
 This post is a simple telling of the beginning of my experience with SWC and hopefully first of many encounters with SWC as a community as well as a learning experience.

--- a/_posts/2016/09/2016-09-30-perth.md
+++ b/_posts/2016/09/2016-09-30-perth.md
@@ -4,7 +4,7 @@ authors: ["Andrew Rohl", "Matthias Liffers", "Andrea Bedini"]
 title: "Perth Software Carpentry - A Tale of Three Trainers"
 date: 2016-09-30
 time: "00:10:00"
-category: ["community", "workshops"]
+category: ["Community", "Workshops"]
 ---
 
 ### Andrew

--- a/_posts/2016/10/2016-10-10-rules-election.md
+++ b/_posts/2016/10/2016-10-10-rules-election.md
@@ -4,7 +4,7 @@ authors: ["Kate Hertweck"]
 title: "Vote Next Week to Amend Steering Committee Election Procedures"
 date: 2016-10-10
 time: "09:00:00"
-category: ["steering committee"]
+category: ["Steering Committee"]
 ---
 
 Last month, the Steering Committee announced a 


### PR DESCRIPTION
Deduplicate [the category page][1] somewhat with the following changes:

* “Sponsors” → “Funding”
* “Support” → “Funding”
* “Training” → “Instructor Training”
* “Translations” → “Translation”
* “Workshop” → “Workshops”
* “community” → “Community”
* “education” → “Education”
* “instructor-training” → “Instructor Training”
* “steering committee” → “Steering Committee”
* “surveys” → “Surveys”
* “workshops” → “Workshops”

[1]: https://software-carpentry.org/blog/categories/