### PR TITLE
_posts: Use “Election YYYY” instead of an “Elections” category

### DIFF
--- a/_posts/2015/12/2015-12-08-call-for-candidates-elections-2016.html
+++ b/_posts/2015/12/2015-12-08-call-for-candidates-elections-2016.html
@@ -4,7 +4,7 @@ authors: ["Jonah Duckles"]
 title: "Call for Candidates for the 2016 Steering Committee"
 date: 2015-12-08
 time: "17:00:00"
-category: ["Community", "Elections", "Steering Committee"]
+category: ["Community", "Election 2016", "Steering Committee"]
 ---
 <p>From February 15-19, Software Carpentry will hold its annual election for the
 Steering Committee of The Software Carpentry Foundation. The inaugural Steering

--- a/_posts/2016/10/2016-10-24-Call-for-candidates-SC-2017.md
+++ b/_posts/2016/10/2016-10-24-Call-for-candidates-SC-2017.md
@@ -4,7 +4,7 @@ authors: ["Kate Hertweck"]
 title: "Call for Candidates for the 2017 Steering Committee"
 date: 2016-10-24
 time: "08:00:00"
-category: ["Community", "Elections", "Steering Committee"]
+category: ["Community", "Election 2017", "Steering Committee"]
 ---
 
 Software Carpentry will hold its annual election for the

--- a/_posts/2016/12/2016-12-12-election-reminder.md
+++ b/_posts/2016/12/2016-12-12-election-reminder.md
@@ -4,7 +4,7 @@ authors: ["Kate Hertweck"]
 title: "Don't forget to submit your post to stand for the 2017 Steering Committee"
 date: 2016-12-12
 time: "00:12:00"
-category: ["Community", "Elections", "Steering Committee"]
+category: ["Community", "Election 2017", "Steering Committee"]
 ---
 
 If you've considered running for the 2017 Software Carpentry Steering Committee, 

--- a/_posts/2016/2016-12-05-election-sue-mcclatchy.md
+++ b/_posts/2016/2016-12-05-election-sue-mcclatchy.md
@@ -4,7 +4,7 @@ authors: ["Sue McClatchy"]
 title: "2017 Election: Sue McClatchy"
 date: 2016-12-05
 time: "14:00:00"
-category: ["Software Carpentry Foundation", "Elections", "Steering Committee"]
+category: ["Software Carpentry Foundation", "Election 2017", "Steering Committee"]
 ---
 
 Hi,


### PR DESCRIPTION
Most of the existing posts have the year in the title, so “Elections” would be fine.  But the explicit-year categories are more popular:

    $ git grep '^category:.*"Elections"' origin/gh-pages | wc -l
    4
    $ git grep '^category:.*"Election [0-9]\{4\}"' origin/gh-pages | wc -l
    32

So consolidate around that pattern.