### PR TITLE
Defining open online instructor training

### DIFF
--- a/pages/join.html
+++ b/pages/join.html
@@ -46,11 +46,13 @@ There are two steps to becoming an instructor:
 
 <p align="center">
   <em>
-    Registration for the Fall 2016 training courses is now closed, but
-    we are still accepting applications for subsequent courses.  If
-    you would like to apply, or are taking the course through one of
-    our partner organizations and have been asked to provide information,
-    please fill in <a href="{{site.amy_url}}/request_training/">this form</a>.
+    Most of our instructors are trained through organizational agreements 
+    with affiliated institutions. If you have been asked to provide 
+    information associated with this type of training, 
+    please fill in <a href="{{site.amy_url}}/request_training/">this form</a>. 
+    If you are not affiliated with one of our partner organizations, we offer limited 
+    scholarships to attend online instructor training. Please fill out the form above to 
+    indicate your interest in participating in an upcoming instructor training.
   </em>
 </p>
 


### PR DESCRIPTION
This PR follows Steering Committee passage of a motion in late November 2016 that allows four open online trainings a year. This minor change in language defines our instructor training as taking place primarily through organizational memberships, with open online training being allowed through scholarships. Further suggestions for clarity are welcome and will be discussed at the January Steering Committee meeting.

Other related tasks:

- update the AMY form that still includes language to fall 2016 training
- post more information about how scholarships are chosen (rubric) and timeline for acceptance