### PR TITLE
adding second names to videos of lessons co-taught at Scipy 2015

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -201,11 +201,11 @@ redirect_from:
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=pB3BFP001co">Software Carpentry: Python (SciPy 2015)</a></td>
-    <td><a href="{{site.baseurl}}/team/#huff_k">Katy Huff</a></td>
+    <td><a href="{{site.baseurl}}/team/#huff_k">Katy Huff</a> and Thomas Kluyver</td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=hKFNPxxkbO0">Software Carpentry: Git (SciPy 2015)</a></td>
-    <td><a href="{{site.baseurl}}/team/#hart_t">Ted Hart</a></td>
+    <td><a href="{{site.baseurl}}/team/#hart_t">Ted Hart</a> and <a href="{{site.baseurl}}/team/#bostroem_a">Azalee Bostroem</a></td>
   </tr>
   <tr>
     <td><a href="https://www.youtube.com/watch?v=x-5WNfopFTc">Software Carpentry: Scientific Python (SciPy 2015)</a></td>


### PR DESCRIPTION
At Scipy 2015 most of the lessons were co-taught. The current website only shows the name of the first person to teach. I've updated the Python and the Git lessons to reflect both people.