### PR TITLE
fix image URLs

### DIFF
--- a/_posts/2015/03/2015-03-25-teaching-in-yangon.html
+++ b/_posts/2015/03/2015-03-25-teaching-in-yangon.html
@@ -34,7 +34,7 @@ category: ["Workshops", "University of Yangon"]
 </p>
 <!--more-->
 <p>
-  <img src="{{site.filesurl}}/2015/03/{{site.filesurl}}/2015/03/burma-01.jpg" alt="Class in Yangon" class="responsive" />
+  <img src="{{site.filesurl}}/2015/03/burma-01.jpg" alt="Class in Yangon" class="responsive" />
 </p>
 <p>
   The first major adaptation was evident right at the start: software
@@ -140,5 +140,5 @@ category: ["Workshops", "University of Yangon"]
   unlikely to hear about it from within their research community.
 </p>
 <p>
-  <img src="{{site.filesurl}}/2015/03/{{site.filesurl}}/2015/03/burma-03.jpg" alt="Class Photo in Yangon" class="responsive" />
+  <img src="{{site.filesurl}}/2015/03/burma-03.jpg" alt="Class Photo in Yangon" class="responsive" />
 </p>


### PR DESCRIPTION
I wasn't seeing the pics on https://software-carpentry.org/blog/2015/03/teaching-in-yangon.html, and needed them for a presentation (https://www.ethz.ch/en/the-eth-zurich/global/eth-global-news-events/2017/01/mathematical-and-data-sciences-for-development.html). I followed the format used for images in https://software-carpentry.org/blog/2015/03/workshop-in-krakow.html and https://github.com/swcarpentry/website/blob/gh-pages/_posts/2015/03/2015-03-04-workshop-in-krakow.html to make the corrections here. Thanks!