### PR TITLE
Added 'Assessment' page

### DIFF
--- a/pages/assessment.md
+++ b/pages/assessment.md
@@ -1,0 +1,17 @@
+# Assessment  
+
+Software Carpentry values a culture of assessment, and we are consistently evaluating our workshops to understand the impact workshops have on our learners.
+
+# Surveys  
+We conduct pre and post workshop surveys for each of our workshops:
+
+- [Pre-workshop survey](https://www.surveymonkey.com/r/Preview/?sm=V6gQbbOKn3NoPKfYKHjAKu_2BBCdtXXsTS2pf1BIdARccEtJQqlu1KFB2j2TcF0MCn)
+
+- [Post-workshop survey](https://www.surveymonkey.com/r/Preview/?sm=uN5QPa4MbF1_2BB1plbLWnL1ZUc7Nttqici0Nc0e3G4RahMwwGW5NUp4U5PKQDYmky)
+
+Additionally, we began collecting data on the long-term impact our workshops are having on both Data Carpentry and Software Carpentry learners. The [Carpentry Long-Term Feedback Survey](https://www.surveymonkey.com/r/Preview/?sm=LksuekfCD3hzLW6lPkx9qhkRF5nDt8uGWpN7lq2Mx0Dqw1Zriv3qYFpu3XtR46ei) was launched in March 2017, and data will be collected every 6 months.
+
+- [Carpentry Long-Term Feedback Survey](https://www.surveymonkey.com/r/Preview/?sm=LksuekfCD3hzLW6lPkx9qhkRF5nDt8uGWpN7lq2Mx0Dqw1Zriv3qYFpu3XtR46ei)
+
+# Data  
+Data sets to go along with assessment reports are provided in a [GitHub repository](https://github.com/carpentries/public-survey-info), along with the version of the surveys that were in use at time of analysis.

--- a/pages/assessment.md
+++ b/pages/assessment.md
@@ -1,8 +1,16 @@
-# Assessment  
+---
+layout: page-fullwidth
+permalink: /assessment/
+title: Assessment
+redirect_from:
+  - /pages/assessment.html
+---
+
+## Assessment  
 
 Software Carpentry values a culture of assessment, and we are consistently evaluating our workshops to understand the impact workshops have on our learners.
 
-# Surveys  
+## Surveys  
 We conduct pre and post workshop surveys for each of our workshops:
 
 - [Pre-workshop survey](https://www.surveymonkey.com/r/Preview/?sm=V6gQbbOKn3NoPKfYKHjAKu_2BBCdtXXsTS2pf1BIdARccEtJQqlu1KFB2j2TcF0MCn)
@@ -11,7 +19,5 @@ We conduct pre and post workshop surveys for each of our workshops:
 
 Additionally, we began collecting data on the long-term impact our workshops are having on both Data Carpentry and Software Carpentry learners. The [Carpentry Long-Term Feedback Survey](https://www.surveymonkey.com/r/Preview/?sm=LksuekfCD3hzLW6lPkx9qhkRF5nDt8uGWpN7lq2Mx0Dqw1Zriv3qYFpu3XtR46ei) was launched in March 2017, and data will be collected every 6 months.
 
-- [Carpentry Long-Term Feedback Survey](https://www.surveymonkey.com/r/Preview/?sm=LksuekfCD3hzLW6lPkx9qhkRF5nDt8uGWpN7lq2Mx0Dqw1Zriv3qYFpu3XtR46ei)
-
-# Data  
+## Data  
 Data sets to go along with assessment reports are provided in a [GitHub repository](https://github.com/carpentries/public-survey-info), along with the version of the surveys that were in use at time of analysis.


### PR DESCRIPTION
@jduckles I added an 'Assessment' page with links to the public-survey-info repo. I don't know how to make sure this shows up under the 'About' dropdown. Can you make it go? :)