### PR TITLE
Fix metadata

### DIFF
--- a/_posts/2017/04/2017-04-26-lcsprint.md
+++ b/_posts/2017/04/2017-04-26-lcsprint.md
@@ -4,7 +4,7 @@ authors: ["Belinda Weaver"]
 title: "Library Carpentry sprint in June"
 date: 2017-04-26
 time: "10:00:00"
-category: ["Library Carpentry" "hackathons"]
+category: ["Library Carpentry", "hackathons"]
 ---
 
 Lesson maintenance is necessarily an ongoing task, especially with fledgling lessons where workshops taught 


### PR DESCRIPTION
 #702 has a bug on the YAML header. This pull request will fix it.

The broken YAML header is creating issues for the [post](https://software-carpentry.org/blog/2017/04/2017-04-26-lcsprint.html) not be render properly.

![screencapture-software-carpentry-org-blog-2017-04-2017-04-26-lcsprint-html-1493210516952](https://cloud.githubusercontent.com/assets/1506457/25434950/3c3dabd2-2a86-11e7-853c-15dc50d91584.png)

You can't access the blog post from the homepage.

![screencapture-software-carpentry-org-1493210583301](https://cloud.githubusercontent.com/assets/1506457/25434989/6d6c079e-2a86-11e7-9764-7b188e8c2c00.png)

Extra: The blog post is flooding Slack.

![screencapture-swcarpentry-slack-messages-c03le48ay-1493210664433](https://cloud.githubusercontent.com/assets/1506457/25435061/b3716018-2a86-11e7-8571-1fd9917a5c6c.png)
 