### PR TITLE
Added hyperlink to the name

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -286,6 +286,6 @@ redirect_from:
     <td>Programming with GAP</td>
     <td><a href="http://alex-konovalov.github.io/gap-lesson" target="_blank" class="icon-browser" title="icon-browser"></a></td>
     <td><a href="https://github.com/alex-konovalov/gap-lesson" target="_blank" class="icon-github" title="icon-github"></a></td>
-    <td>Alex Konovalov</td>
+    <td><a href="{{site.baseurl}}/team/#konovalov_alexander">Alexander Konovalov</a></td>
   </tr>
 </table>


### PR DESCRIPTION
Just noticed that my name has no link to the profile, since the lesson was added to the list before I've became an instructor.