### PR TITLE
Correct public assesment typos

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -26,7 +26,7 @@
     url: "/scf/awards/"
   - title: "Privacy Policy"
     url: "/privacy/"
-  - title: "Assesment"
+  - title: "Assessment"
     url: "/assessment/"
 
 - title: "Workshops"

--- a/_posts/2015/04/2015-04-13-weekly-update-2015-04-13.html
+++ b/_posts/2015/04/2015-04-13-weekly-update-2015-04-13.html
@@ -32,7 +32,7 @@ category: ["Community"]
     Do you have suggestions to include in a <a href="{{site.baseurl}}/blog/2015/04/project-inception-deck-for-research-coding.html">10-step inception deck</a> that could facilitate alignment of goals for research coding projects? Please share your thoughts with us. 
   </li>
   <li>
-    Highlights from the <a href="http://k8hert.blogspot.co.uk/2015/03/data-carpentry-hackathon-for-genomics.html">Data Carpentry Genomics and Assesment hackathon</a> held in March have been posted by Kate Hertweck.
+    Highlights from the <a href="http://k8hert.blogspot.co.uk/2015/03/data-carpentry-hackathon-for-genomics.html">Data Carpentry Genomics and Assessment hackathon</a> held in March have been posted by Kate Hertweck.
     (See also <a href="http://variationselectioninheritance.podbean.com/e/whats-a-hackathon-anyway/">this post</a> for another perspective.)
   </li>
   <li>


### PR DESCRIPTION
'Assesment' typo corrected (but only for the rendered content...not the comments)