### PR TITLE
Remove trailing slash that breaks the url.

### DIFF
--- a/pages/checklists_lead.html
+++ b/pages/checklists_lead.html
@@ -142,7 +142,7 @@ redirect_from:
   </li>
   <li>
     <p>
-      It is encouraged to participate in an <a href="http://pad.software-carpentry.org/instructor-discussion/">Instructor Discussion session</a> before the workshop to discuss pre-workshop planning. You can also email other instructors who have been involved with the planning process encouraging them to participate in a session as well. Participating in the sessions provides valuable insight to new instructors and can allow you an opportunity to ask questions before your workshop.
+      It is encouraged to participate in an <a href="http://pad.software-carpentry.org/instructor-discussion">Instructor Discussion session</a> before the workshop to discuss pre-workshop planning. You can also email other instructors who have been involved with the planning process encouraging them to participate in a session as well. Participating in the sessions provides valuable insight to new instructors and can allow you an opportunity to ask questions before your workshop.
     </p>
   </li>
 </ul>


### PR DESCRIPTION
Etherpad complains "Such a padname is forbidden" if the slash is at the end.

Compare
http://pad.software-carpentry.org/instructor-discussion/ (return the error message above)
with
http://pad.software-carpentry.org/instructor-discussion (works!)