### PR TITLE
Accessibility checklist: add HOH acronym

### DIFF
--- a/pages/checklists_accessibility.html
+++ b/pages/checklists_accessibility.html
@@ -81,7 +81,7 @@ redirect_from:
   </li>
   <li>
     <p>
-      If any participants are hard of hearing:
+      If any participants are hard of hearing (HOH):
     </p>
     <ul>
       <li>


### PR DESCRIPTION
The acronym is not well known for non-native speakers.