### PR TITLE
Update link to training materials

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,7 +65,7 @@ mailing_lists   : "http://lists.software-carpentry.org"
 flag_size       : 16
 v4_url          : "https://v4.software-carpentry.org"
 releases_io_url : "http://swcarpentry.github.io/swc-releases"
-training_url    : "http://swcarpentry.github.io/instructor-training"
+training_url    : "http://carpentries.github.io/instructor-training"
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -272,7 +272,7 @@ excerpt: These are our most frequently asked questions
   <dd>
     <p>
       Becoming an instructor in the Carpentries requires that you take a two-day workshop we call
-      <a href="http://swcarpentry.github.io/instructor-training/">Instructor Training</a>.
+      <a href="http://carpentries.github.io/instructor-training/">Instructor Training</a>.
 
 To request training as an instructor, please fill out <a href="https://amy.software-carpentry.org/forms/request_training/">this form</a>.
 

--- a/pages/instructor_training.html
+++ b/pages/instructor_training.html
@@ -2,6 +2,6 @@
 layout: redirect
 sitemap: false
 permalink: /instructor-training/
-redirect_to:  https://swcarpentry.github.io/instructor-training/
+redirect_to:  https://carpentries.github.io/instructor-training/
 excerpt: Our instructor training curriculum is updated six-monthly
 ---

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -135,9 +135,9 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
   </tr>
   <tr id="training">
     <td>Instructor Training</td>
-    <td><a href="{{site.github_io_url}}/instructor-training" target="_blank" class="icon-browser" title="Instructor Training"></a></td>
-    <td><a href="{{site.github_url}}/instructor-training" target="_blank" class="icon-github" title="Instructor Training"></a></td>
-    <td><a href="{{site.github_io_url}}/instructor-training/reference/" target="_blank" class="icon-eye" title="Instructor Training"></a></td>
+    <td><a href="https://carpentries.github.io/instructor-training/"_blank" class="icon-browser" title="Instructor Training"></a></td>
+    <td><a href="https://github.com/carpentries/instructor-training" target="_blank" class="icon-github" title="Instructor Training"></a></td>
+    <td><a href="https://carpentries.github.io/instructor-training/reference/" target="_blank" class="icon-eye" title="Instructor Training"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#becker_erin">Erin Becker</a>,
       <a href="{{site.baseurl}}/team/#koch_christina.html">Christina Koch</a>


### PR DESCRIPTION
Updated links to training materials to go to carpentries organization on GitHub.

@weaverbel @maneesha @jduckles Please review and merge.