### PR TITLE
attempt to force static site generator to initialise lists correctly

### DIFF
--- a/_posts/2017/10/2017-10-05-mentoring-round-2.md
+++ b/_posts/2017/10/2017-10-05-mentoring-round-2.md
@@ -18,6 +18,7 @@ According to round one participants, the benefits of mentoring included greater 
 Participants felt the program could be improved if mentoring groups had specific goals, and if we gave mentors more guidance on how to run mentoring sessions.
 
 We listened to that feedback and have made changes to the program. We are now offering curriculum-specific mentoring: both mentors and mentees can choose which tools they are most interested in discussing from the following list:
+
 + Git  
 + Shell  
 + Python  
@@ -25,6 +26,7 @@ We listened to that feedback and have made changes to the program. We are now of
 + SQL
 
 Once a topic has been selected, participants can choose what aspect of mentoring they want for their chosen tool:
+
 + Lesson Maintenance  
   - Contributing to current lesson development  
   - Contributing to lesson maintenance  
@@ -34,7 +36,7 @@ Once a topic has been selected, participants can choose what aspect of mentoring
 
 Additionally, we plan to offer mentoring on two big issues:
 
- Organizing Workshops   
++ Organizing Workshops
   - Logistics of organizing a workshop (e.g. marketing, registration)  
   - Logistics of running a workshop (e.g. recruiting instructors, distributing tasks)  
 + Community Building  


### PR DESCRIPTION
The [blog post](https://software-carpentry.org/blog/2017/10/mentoring-round-2.html) looks a bit garbled in Firefox, Safari & Chrome:

![screen shot 2017-10-07 at 16 00 03](https://user-images.githubusercontent.com/9948149/31308559-01e345ea-ab79-11e7-9fda-ffa3ed098101.png)

Maybe there is a mismatch somewhere between the expected and current MarkDown flavor?