### PR TITLE
Added Before/After to pre-/post-workshop debrief at instructor discussion

### DIFF
--- a/pages/checklists_helper.html
+++ b/pages/checklists_helper.html
@@ -60,6 +60,13 @@ excerpt: The role a helper plays at a Software Carpentry workshop
   </li>
   <li>
     <p>
+      Sign up to participate in a 
+      <a href="http://pad.software-carpentry.org/instructor-discussion">pre-workshop discussion</a>  
+      with the mentoring committee. 
+    </p>
+  </li>
+  <li>
+    <p>
       Read the blog posts by 
       <a href="{{site.baseurl}}/blog/2012/10/how-to-help-at-a-boot-camp.html">Katy Huff</a>
       and
@@ -111,6 +118,13 @@ excerpt: The role a helper plays at a Software Carpentry workshop
 
 <h2>After</h2>
 <ul>
+  <li>
+    <p>
+      Sign up to participate in a 
+      <a href="http://pad.software-carpentry.org/instructor-discussion">post-workshop discussion</a>  
+      with the mentoring committee. 
+    </p>
+  </li>
   <li>
     <p>
       Consider writing a blog post about your experience.


### PR DESCRIPTION
We haven't encouraged helpers to participated in instructor discussions before.  However, it might be a good place for them to hear about other perspectives in preparation and provide feedback on workshops they help out with. 