### PR TITLE
audience.html: Add separations between people

### DIFF
--- a/pages/audience.html
+++ b/pages/audience.html
@@ -63,6 +63,8 @@ excerpt: Software Carpentry uses learner profiles to inform what we teach
   </div>
 </div>
 
+<hr/>
+
 <div class="row">
   <div class="medium-3 columns">
     <h2>Fan Fullerene</h2>
@@ -113,6 +115,8 @@ excerpt: Software Carpentry uses learner profiles to inform what we teach
     </p>
   </div>
 </div>
+
+<hr/>
 
 <div class="row">
   <div class="medium-3 columns">
@@ -165,6 +169,8 @@ excerpt: Software Carpentry uses learner profiles to inform what we teach
     </p>
   </div>
 </div>
+
+<hr/>
 
 <div class="row">
   <div class="medium-3 columns">


### PR DESCRIPTION
Currently it is hard to tell where one character's bio ends and the next starts. This patch adds horizontal lines between them.

<details>
<summary>
Screenshots
</summary>

<img width="502" alt="before" src="https://user-images.githubusercontent.com/426784/32001330-7bbe2960-b967-11e7-964e-502ba4880234.png">

becomes

<img width="492" alt="after" src="https://user-images.githubusercontent.com/426784/32001343-8696bf78-b967-11e7-939a-7d82fbd56536.png">

</details>