### PR TITLE
Add where Samantha Ahern is based

### DIFF
--- a/_posts/2017/11/2017-11-26-sc-candidates-2018.md
+++ b/_posts/2017/11/2017-11-26-sc-candidates-2018.md
@@ -11,7 +11,7 @@ Eight people have nominated to serve on the 2018 Steering Committee of the new, 
 
 The nominees so far are:
 
-- [Samantha Ahern](https://software-carpentry.org/blog/2017/11/sam-ahern-sc.html)
+- [Samantha Ahern](https://software-carpentry.org/blog/2017/11/sam-ahern-sc.html) (UK)
 - [Martin Callaghan](https://software-carpentry.org/blog/2017/11/election-callaghan.html) (UK)
 - [Auriel Fournier](https://software-carpentry.org/blog/2017/11/2018-sc-election-fournier.html) (US)
 - [Amy Hodge](https://software-carpentry.org/blog/2017/11/amy-hodge-sc.html) (US)


### PR DESCRIPTION
This change https://software-carpentry.org/blog/2017/11/sc-candidates-2018.html so that **all** candidates have the country where they are living after their name.