### PR TITLE
add new maintainers

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -52,7 +52,8 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice/reference" target="_blank" class="icon-eye" title="The Unix Shell"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#devenyi_gabriel">Gabriel Devenyi</a>,
-      <a href="{{site.baseurl}}/team/#srinath_ashwin">Ashwin Srinath</a>
+      <a href="{{site.baseurl}}/team/#srinath_ashwin">Ashwin Srinath</a>,
+      Colin Morris
     </td>
   </tr>
   <tr id="git">
@@ -62,7 +63,9 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice/reference" target="_blank" class="icon-eye" title="Version Control with Git"></a></td>
     <td>
       <a href="{{site.baseurl}}/team/#gonzalez_ivan">Ivan Gonzalez</a>,
-      <a href="{{site.baseurl}}/team/#huang_daisie">Daisie Huang</a>
+      <a href="{{site.baseurl}}/team/#huang_daisie">Daisie Huang</a>,
+      <a href="{{site.baseurl}}/team/#hejazi_nima">Nima Hejazi</a>,
+      Katherine Koziar
     </td>
   </tr>
   <tr id="hg">
@@ -92,6 +95,16 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <a href="{{site.baseurl}}/team/#bekolay_trevor">Trevor Bekolay</a>,
       <a href="{{site.baseurl}}/team/#staneva_valentina">Valentina Staneva</a>
     </td>
+  </tr>
+  <tr id="python-gap">
+      <td>Plotting and Programming in Python</td>
+      <td><a href="{{site.github_io_url}}/python-novice-gapminder" target="_blank" class="icon-browser" title="Plotting and Programming in Python"></a></td>
+      <td><a href="{{site.github_url}}/python-novice-gapminder" target="_blank" class="icon-github" title="Plotting and Programming in Python"></a></td>
+      <td><a href="{{site.github_io_url}}/python-novice-gapminder/reference" target="_blank" class="icon-eye" title="Plotting and Programming in Python"></a></td>
+      <td>
+          <a href="{{site.baseurl}}/team/#moore_nathan">Nathan Moore</a>,
+          Allen Lee
+      </td>
   </tr>
   <tr id="r-prog">
     <td>Programming with R</td>


### PR DESCRIPTION
Adding four new maintainers for SWC lessons. One of the new Maintainers is for the python gapminder lesson, which wasn't on the lesson table. I added it and put the two current maintainers on the list. 

Have done a local preview and confirmed it works!