### PR TITLE
Create 2018-03-06-curriculum-advisors.md

### DIFF
--- a/_posts/2018/02/2018-03-06-curriculum-advisors.md
+++ b/_posts/2018/02/2018-03-06-curriculum-advisors.md
@@ -1,0 +1,37 @@
+---
+layout: post
+authors: ["Erin Becker", "Christina Koch"]
+title: "Call for Contributions: Data Carpentry Ecology and Software Carpentry Curriculum Advisory Committees"
+date: 2018-03-06
+time: "00:00:00"
+category: [ "Curriculum"]
+---
+
+In mid-2017, Data Carpentry piloted a Curriculum Advisory Committee (CAC) for the Genomics curriculum. 
+The goals for this committee were to provide general oversight, vision, and leadership for the full Genomics lesson stack, to ensure 
+that the lessons stay up-to-date with existing best practices in the field, and to continue to serve the needs of genomics practitioners 
+attending our workshops. Genomics Curriculum Advisors met after the 
+[initial Genomics lesson publication in November](http://www.datacarpentry.org/blog/genomics-lesson-release/) 
+to discuss proposed structural and major topical changes to the lessons and will be helping the Genomics Maintainer team 
+to make decisions about these changes as we prepare for a second release this year.
+
+Since first piloting the idea of a CAC, we’ve
+[learned from our Maintainer community](http://www.datacarpentry.org/blog/maintainer-report/) that this type of 
+overall guidance is strongly desired by Maintainers for other lessons! Maintainers often face challenges trying to 
+decide whether proposed large-scale changes are appropriate for their lessons. As Maintainers are usually not deeply
+familiar with other lessons in their curricular stack (and aren’t expected to be!), they often wonder how changes to
+their lesson will affect other lessons taught in the same workshop. Curriculum Advisors help to provide this higher-level
+oversight and take some of this burden away from the lesson Maintainers. 
+
+Due to overwhelming enthusiasm from the Maintainer community, we are now recruiting for Curriculum Advisors for the Data Carpentry 
+Ecology lessons and the Software Carpentry full lesson stack. Applications are open to all Carpentry community members. We strongly
+encourage applications from community members with current classroom teaching experience, university or college faculty and staff, 
+and Maintainers for these lessons. 
+
+Read more about the [role of Curriculum Advisors](https://docs.google.com/document/d/1wIi2CY0fg4LkrlfqbrO47wR-6hR0BE1Qbr5Hu4oeIbg/edit). 
+
+Apply to join the [Data Carpentry Ecology Curriculum Advisory Committee](https://goo.gl/forms/1LKwgq47lCJG9JNZ2)
+
+Apply to join the [Software Carpentry Curriculum Advisory Committee](https://goo.gl/forms/U1RylBhV2HSIVNJg2).
+
+Applications will be open through March 16th, 2018. Please contact Erin Becker (ebecker@carpentries.org) with any questions. 


### PR DESCRIPTION
Add blog post for recruiting members of the Curriculum Advisory committee for DC Ecology and SWC.