### PR TITLE
Fix urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # - https://github.com/jekyll/jekyll-redirect-from
 #
 
-gems:
+plugins:
   - jekyll-redirect-from
   - jekyll-paginate
 

--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,7 @@ flag_size       : 16
 v4_url          : "https://v4.software-carpentry.org"
 releases_io_url : "http://swcarpentry.github.io/swc-releases"
 training_url    : "http://carpentries.github.io/instructor-training"
+carp_gh_io_url  : "http://carpentries.github.io"
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages

--- a/_posts/2015/04/2015-04-06-weekly-update-2015-04-06.html
+++ b/_posts/2015/04/2015-04-06-weekly-update-2015-04-06.html
@@ -20,7 +20,7 @@ category: ["Community"]
 <ul>
   <li>
     Do you need to create a brand new lesson repository?
-    The <a href="{{site.github_io_url}}/slideshows/creating-lesson/index.html">new process is outlined</a> with <a href="http://swcarpentry.github.io/lesson-example">an example</a> - please try it out and send us your comments.
+    The <a href="{{site.github_io_url}}/slideshows/creating-lesson/index.html">new process is outlined</a> with <a href="{{site.carp_gh_io_url}}/lesson-example">an example</a> - please try it out and send us your comments.
   </li>
   <li>
     Damien Irving created a <a href="http://damienirving.github.io/capstone-oceanography/">capstone example specifically for oceanographers</a>.

--- a/_posts/2015/04/2015-04-18-aas-reflections.html
+++ b/_posts/2015/04/2015-04-18-aas-reflections.html
@@ -47,7 +47,7 @@ category: ["Workshops", "American Astronomical Society"]
 <h2>Workshop Set-up</h2>
 <p>
   We decided to use the set-up test script
-  from <a href="http://swcarpentry.github.io/workshop-template/setup/index.html">here</a>. I
+  from <a href="{{site.carp_gh_io_url}}/workshop-template/setup/index.html">here</a>. I
   modified the first test script to test for specific versions of
   numpy, scipy, matplotlib, and astropy. I emailed the modified
   scripts to students prior to the lesson and a link to the

--- a/_posts/2015/11/2015-11-20-morea-framework.html
+++ b/_posts/2015/11/2015-11-20-morea-framework.html
@@ -16,7 +16,7 @@ category: ["Teaching", "Tooling", "Noticed"]
   "Morea" stands for "Modules, Outcomes, Readings, Experiences, and Assessments",
   which are the five main elements the framework supports.
   As you can see from the project <a href="http://morea-framework.github.io/gallery.html">gallery</a>,
-  it's much more structured than <a href="http://swcarpentry.github.io/lesson-example/">our lessons</a>.
+  it's much more structured than <a href="{{site.carp_gh_io_url}}/lesson-example/">our lessons</a>.
   It also requires more tooling&mdash;Morea Framework sites are built using custom Jekyll plugins,
   and the source relies much more heavily on include files than our template&mdash;and
   it's geared very strongly toward traditional semester-long courses.

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -704,7 +704,7 @@ When open training is offered again, it will be offered online, in one-hour sess
       The template for lessons lives in
       <a href="{{site.github_url}}/lesson-example">this GitHub repository</a>.
       For instructions on creating a new lesson or modifying an existing one,
-      please see the <a href="http://swcarpentry.github.io/lesson-example/">lesson example home page</a>
+      please see the <a href="{{ carp_gh_io_url }}/lesson-example/">lesson example home page</a>
       or <a href="https://swcarpentry.github.io/slideshows/creating-lesson/index.html">this slideshow</a>.
     </p>
   </dd>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -185,7 +185,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
   <div class="medium-4 columns">
     <p>
       To learn more about how our lessons are structured, and why,
-      please see <a href="{{site.github_io_url}}/lesson-example">the example lesson</a>.
+      please see <a href="{{site.carp_gh_io_url}}/lesson-example">the example lesson</a>.
     </p>
   </div>
   <div class="medium-4 columns">

--- a/pages/lessons_incubation.md
+++ b/pages/lessons_incubation.md
@@ -57,8 +57,8 @@ do so according to the following criteria:
     require that lessons be created from scratch, and in fact prefer
     contributors to recycle materials they have tested in the
     classroom so long as they meet licensing stipulations. We do
-    require that lessons use our [templates]({{site.github_io_url}}/lesson-example/)
-    and [teaching style]({{site.github_io_url}}/instructor-training/).
+    require that lessons use our [templates]({{site.carp_gh_io_url}}/lesson-example/)
+    and [teaching style]({{site.carp_gh_io_url}}/instructor-training/).
 
 Data Carpentry and Software Carpentry’s Steering Committees may make
 exceptions to these requirements in special cases, but such exceptions


### PR DESCRIPTION
We moved workshop-template, styles, and lesson-example to the Carpentries GitHub organization. This fixes the URLs on the website affected by this change.