### PR TITLE
Update Workshop Operations link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -42,7 +42,7 @@
   - title: "Testimonials"
     url: "/testimonials/"
   - title: "Workshop Operations"
-    url: "/workshops/operations/"
+    url: "https://docs.carpentries.org/topic_folders/workshop_administration/index.html"
   - title: "Past Workshops"
     url: "/workshops/past/"
 


### PR DESCRIPTION
The current link goes to a blank page: should this now go to the relevant section in the handbook?