### PR TITLE
fix jekyll plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # - https://github.com/jekyll/jekyll-redirect-from
 #
 
-plugins_dir:
+plugins:
   - jekyll-paginate
   - jekyll-redirect-from
 


### PR DESCRIPTION
Jekyll plugins need to be referred to as `plugins:` not `plugins-dir:`