### PR TITLE
Updating tags for 2013 SC blog entries

### DIFF
--- a/_posts/2013/01/2013-01-05-cold-call.html
+++ b/_posts/2013/01/2013-01-05-cold-call.html
@@ -4,7 +4,7 @@ title: The Art of Cold Calling
 date: 2013-01-05
 time: "09:00:00"
 root: ../../..
-tags: ["Bootcamps"]
+tags: ["Workshops"]
 ---
 <p><em>
   An updated version of this post is <a href="{{site.baseurl}}/blog/2013/11/updated-cold-call.html">now available</a>.

--- a/_posts/2013/01/2013-01-23-how-to-become-an-instructor.html
+++ b/_posts/2013/01/2013-01-23-how-to-become-an-instructor.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: How to Become an Instructor
 date: 2013-01-23
 time: "09:00:00"
-tags: ["Community"]
+tags: ["Instructor development"]
 ---
 <p>As we've mentioned <a href="{{site.baseurl}}/blog/2012/12/why-be-an-instructor.html">elsewhere</a>, our instructors are volunteers who donate their time because it's fun, because it makes the world a better place, because they learn things themselves from teaching, and because it's good for their careers.  But how did they <em>become</em> instructors?  And how can you become one too?</p>
 <p>Starting with the first question, 21 of our 31 instructors are people who figured out how to do hygienic computational science before we met them (or in some cases, taught <em>us</em> some of what we now teach).  The other 10 started as learners: they attended a bootcamp, then volunteered to help with another, and graduated from that to teaching.  That's how we see the pool of instructors growing in future, so one of my main jobs this year is to regularize that.</p>

--- a/_posts/2013/04/2013-04-08-evaluation-revisited.html
+++ b/_posts/2013/04/2013-04-08-evaluation-revisited.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: Evaluation Revisited
 date: 2013-04-08
 time: "10:00:00"
-tags: ["Education"]
+tags: ["Assessment"]
 ---
 <p>
   Caitlyn Pickens

--- a/_posts/2013/05/2013-05-25-our-infrastructure.html
+++ b/_posts/2013/05/2013-05-25-our-infrastructure.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: Our Infrastructure
 date: 2013-05-25
 time: "09:00:00"
-tags: ["Tooling"]
+tags: ["Infrastructure"]
 ---
 <p>
   As described in these posts from

--- a/_posts/2013/08/2013-08-13-what-we-cover-in-instructor-training.html
+++ b/_posts/2013/08/2013-08-13-what-we-cover-in-instructor-training.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "What We Cover in Instructor Training"
 date: 2013-08-13
 time: "09:00"
-tags: ["Teaching"]
+tags: ["Instructor development"]
 ---
 <p>
   The sixth round of our

--- a/_posts/2013/09/2013-09-02-teaching-librarians-at-harvard.html
+++ b/_posts/2013/09/2013-09-02-teaching-librarians-at-harvard.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Teaching Librarians at Harvard"
 date: 2013-09-02
 time: "09:30:00"
-tags: ["Bootcamps", "Harvard University"]
+tags: ["Library Carpentry"]
 ---
 <p>
   Last weekend,

--- a/_posts/2013/11/2013-11-16-instructor-training-in-three-days.html
+++ b/_posts/2013/11/2013-11-16-instructor-training-in-three-days.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Instructor Training in Three Days"
 date: 2013-11-16
 time: "06:00:00"
-tags: ["Announcements", "Instructor Training"]
+tags: ["Instructor development"]
 ---
 <p><em>
   Update:

--- a/_posts/2013/11/2013-11-25-instructor-training-in-toronto.html
+++ b/_posts/2013/11/2013-11-25-instructor-training-in-toronto.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "Registration Now Open for Instructor Training Course"
 date: 2013-11-25
 time: "07:00:00"
-tags: ["Announcements", "Instructor Training"]
+tags: ["Instructor development"]
 ---
 <p>
   As <a href="{{site.baseurl}}/blog/2013/11/instructor-training-in-three-days.html">announced last week</a>,

--- a/_posts/2013/12/2013-12-19-instructor-stats.html
+++ b/_posts/2013/12/2013-12-19-instructor-stats.html
@@ -4,7 +4,7 @@ authors: ["Greg Wilson"]
 title: "So How Is Instructor Training Going?"
 date: 2013-12-19
 time: "09:00:00"
-tags: ["Instructor Training"]
+tags: ["Instructor development"]
 ---
 <p>
   We recently wrapped up the latest round of instructor training,


### PR DESCRIPTION
I worked through the 2013 blogs from SC, and found those where I was comfortable assigning one of the tags on this list https://github.com/carpentries/carpentries.org/pull/484 to the posts. Lots of posts in this year that are reports of individual workshops - wasn't at all sure how to tag them, so left them alone.