### PR TITLE
Link to Help Wanted page from Development Dashboard

### DIFF
--- a/pages/lessons_dashboard.html
+++ b/pages/lessons_dashboard.html
@@ -8,7 +8,7 @@ excerpt: dashboard for lesson status
 ---
 <p>Last rebuilt {{site.data.dashboard.timestamp}}.</p>
 
-Looking for a way to contribute to our lessons? Visit <a href="https://carpentries.org/help-wanted-issues/">the Help Wanted page on The Carpentries website</a> to see a list of issues in need of attention on Software Carpentry, <a href="https://datacarpentry.org/">Data Carpentry</a>, <a href="https://librarycarpentry.org">Library Carpentry</a>, <a href="https://carpentries.org">The Carpentries</a>, <a href="https://carpentries.org/community-lessons">CarpentriesLab</a>, and <a href="https://carpentries.org/community-lessons">Carpentries Incubator</a> repositories.
+Looking for a way to contribute to our lessons? Visit <a href="https://carpentries.org/help-wanted-issues/">the Help Wanted page on The Carpentries website</a> to see a list of issues in need of attention.
 
 {% for record in site.data.dashboard.records %}
   <h2>{{record.description}}: <a href="{{record.url}}">{{record.ident}}</a></h2>

--- a/pages/lessons_dashboard.html
+++ b/pages/lessons_dashboard.html
@@ -7,6 +7,9 @@ redirect_from:
 excerpt: dashboard for lesson status
 ---
 <p>Last rebuilt {{site.data.dashboard.timestamp}}.</p>
+
+Looking for a way to contribute to our lessons? Visit <a href="https://carpentries.org/help-wanted-issues/">the Help Wanted page on The Carpentries website</a> to see a list of issues in need of attention on Software Carpentry, <a href="https://datacarpentry.org/">Data Carpentry</a>, <a href="https://librarycarpentry.org">Library Carpentry</a>, <a href="https://carpentries.org">The Carpentries</a>, <a href="https://carpentries.org/community-lessons">CarpentriesLab</a>, and <a href="https://carpentries.org/community-lessons">Carpentries Incubator</a> repositories.
+
 {% for record in site.data.dashboard.records %}
   <h2>{{record.description}}: <a href="{{record.url}}">{{record.ident}}</a></h2>
   <table class="table table-striped">


### PR DESCRIPTION
Proposing this as part of my sweep through our websites and documentation to include references to [the Help Wanted page](https://carpentries.org/help-wanted-issues/). The top of the Development Dashboard page felt like the most appropriate place to link to that page, as I guess this is where would-be contributors would be most likely to come? But perhaps you'd prefer not to preface the dashboard with this extra text? Please also feel free to suggest alternative/additional places to link out to the Help Wanted page.