### PR TITLE
Redirect Get Involved->Help Wanted to https://carpentries.org/help-wanted-issues/

### DIFF
--- a/pages/join_helpwanted.html
+++ b/pages/join_helpwanted.html
@@ -4,8 +4,6 @@ permalink: /join/help/
 title: Help Wanted
 redirect_from:
   - /pages/projects.html
-redirect_to: https://carpentries.org/community/
+redirect_to: https://carpentries.org/help-wanted-issues/
 excerpt: help wanted with projects or tasks
 ---
-
-


### PR DESCRIPTION
Related to #1175, this changes the redirect from "Help Wanted" on the "Get Involved" dropdown to point at the new [Help Wanted page](https://carpentries.org/help-wanted-issues/) instead of the [Join our Community](https://carpentries.org/community/) page.