### PR TITLE
Workshop style Self/Centrally-Organised

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ which is used to generate the site's pull-down navigation menu.
 <a name="workshop"></a>
 To **add a workshop**,
 fill in the [workshop request form](https://amy.carpentries.org/workshops/swc/request/) online.
-You should fill in this form even for self-organized workshops in order to get your workshop into our database.
+You should fill in this form even for Self-Organised workshops in order to get your workshop into our database.
 
 Do *not* edit the YAML in `_data/amy.yml`:
 this is overwritten every time the website is rebuilt on the server.

--- a/_posts/2015/10/2015-10-26-call-for-instructor-training.html
+++ b/_posts/2015/10/2015-10-26-call-for-instructor-training.html
@@ -65,7 +65,7 @@ instructor has an opportunity to teach after the training.
 <h3>Is is absolutely necessary that our group members have attended a Software Carpentry workshop before?</h3>
 <p><strong>No.</strong> If you live in one city that had a couple of Software Carpentry workshop in the past year we hope that you had attend at least one of our workshops. If you live somewhere that never had one of our workshops we expected that you are comfortable with the content of at least one of our lessons <strong>and</strong> participate in any local project that help people learn programming.</p>
 <h3>There is any cost for me or the institution that I'm affiliated?</h3>
-<p><strong>No.</strong> This round of instruction training is free. The workshop that your group will need to organize will be considered self-organized so you or the instruction that you are affiliated do not own anything to Software Carpentry Foundation. If the institution that you are affiliated can make a donation related with the instructor training and/or the workshop we will be grateful.</p>
+<p><strong>No.</strong> This round of instruction training is free. The workshop that your group will need to organize will be considered Self-Organised so you or the instruction that you are affiliated do not own anything to Software Carpentry Foundation. If the institution that you are affiliated can make a donation related with the instructor training and/or the workshop we will be grateful.</p>
 <h3 id="timeline">What is the timeline</h3>
 <ul>
 <li>2015-10-26: blog post announcing the selection goes online.</li>

--- a/_posts/2016/05/2016-05-02-new-partnerships.md
+++ b/_posts/2016/05/2016-05-02-new-partnerships.md
@@ -13,9 +13,9 @@ We've been hearing of the interest of organizations to build local capacity for 
 ### [Partnership Information]({{site.url}}/scf/join)
 **There are four tiers of Partnerships: Bronze, Silver, Gold and Platinum.**
 
-We wanted to provide opportunities for organizations to run multiple workshops, but who aren't currently planning to train instructors (Bronze) and help organizations build local capacity with instructor training, coordinated workshops and self-organized workshops (Silver, Gold). There is also a flexible tier for organizations who are advancing beyond just capacity building and on to sustainment and wide adoption of our methods across disciplines (Platinum).
+We wanted to provide opportunities for organizations to run multiple workshops, but who aren't currently planning to train instructors (Bronze) and help organizations build local capacity with instructor training, coordinated workshops and Self-Organised workshops (Silver, Gold). There is also a flexible tier for organizations who are advancing beyond just capacity building and on to sustainment and wide adoption of our methods across disciplines (Platinum).
 
-In all Partnerships, some coordinated workshops are included, so that organizations are freely able (with a small travel budget) to bring in outside instructors to help mentor new instructors and continue to encourage cross-connections of instructors across organizational boundaries. Also, all Partner organizations can run as many self-organized workshops as they like.
+In all Partnerships, some coordinated workshops are included, so that organizations are freely able (with a small travel budget) to bring in outside instructors to help mentor new instructors and continue to encourage cross-connections of instructors across organizational boundaries. Also, all Partner organizations can run as many Self-Organised workshops as they like.
 
 All currently in-place partnerships with the Software Carpentry Foundation will be grandfathered into a joint partnership consistent with their current contract until the current partnership expires, at which time they can select to have a joint partnership or a standalone Software Carpentry or Data Carpentry partnership as they choose.
 

--- a/_posts/2016/05/2016-05-23-first-dc-r-darwin.md
+++ b/_posts/2016/05/2016-05-23-first-dc-r-darwin.md
@@ -13,7 +13,7 @@ The [COMBINE](https://combine.org.au/) [Data Carpentry](http://www.datacarpentry
 [Charles Darwin University](http://www.cdu.edu.au/) was filled with joy, enthusiastic attendees 
 and extra degrees of warm.
 
-This was a self-organised workshop led by COMBINE with help of local organisers mainly 
+This was a Self-Organised workshop led by COMBINE with help of local organisers mainly 
 from the [Menzies School of Health Research](http://www.menzies.edu.au/). After some emailing back 
 and forth, three months before the workshop, we planned to have an R data carpentry workshop based 
 on the answers of a custom-made survey (prepared by Steven). Then, two COMBINE instructors were called, 

--- a/_posts/2016/08/2016-08-08-workshop-resources.md
+++ b/_posts/2016/08/2016-08-08-workshop-resources.md
@@ -10,7 +10,7 @@ tags: ["Workshops"]
 A successful workshop is the result of coordinated effort among many different types of participants,
 including instructors, helpers, hosts, learners and staff.
 Software and Data Carpentry offer two types of workshops:
-Self-Organised and centrally-organized.
+Self-Organised and Centrally-Organised.
 These workshop types differ in terms of instructor training requirements,
 fee structures,
 and participant responsibilities,
@@ -20,9 +20,9 @@ normally handled by Carpentry staff.
 Instructors (both new and experienced) and workshop hosts
 often have questions about their roles in workshops logistics,
 especially with how their responsibilities differ
-between Self-Organised and centrally-organized workshops.
+between Self-Organised and Centrally-Organised workshops.
 To help clarify the roles played by the different participants,
-and the differences between self- and centrally-organized workshops,
+and the differences between self- and Centrally-Organised workshops,
 we've put together some resources
 to guide participants through the workshop organizational process.  
 
@@ -33,9 +33,9 @@ and include:
 
 - Checklists for:  
     - [instructors]({{site.dc_url}}/instructor-checklist/)  
-    - [hosts for centrally-organized workshops]({{site.dc_url}}/host-checklist/)
+    - [hosts for Centrally-Organised workshops]({{site.dc_url}}/host-checklist/)
     - [hosts/lead instructors for Self-Organised workshops]({{site.dc_url}}/self-org-lead/) 
-    - and [lead instructors for centrally-organized workshops]({{site.dc_url}}/hosted-lead/)  
+    - and [lead instructors for Centrally-Organised workshops]({{site.dc_url}}/hosted-lead/)  
 - [Email templates]({{site.dc_url}}/email-templates/) for communicating with co-instructors, helpers, and learners  
 - An [accessibility]({{site.dc_url}}/accessibility/) checklist  
 - A list of necessary [equipment]({{site.dc_url}}/equipment-checklist/) and  

--- a/_posts/2016/08/2016-08-08-workshop-resources.md
+++ b/_posts/2016/08/2016-08-08-workshop-resources.md
@@ -10,17 +10,17 @@ tags: ["Workshops"]
 A successful workshop is the result of coordinated effort among many different types of participants,
 including instructors, helpers, hosts, learners and staff.
 Software and Data Carpentry offer two types of workshops:
-self-organized and centrally-organized.
+Self-Organised and centrally-organized.
 These workshop types differ in terms of instructor training requirements,
 fee structures,
 and participant responsibilities,
-with local hosts and instructors at self-organized workshops taking on administrative responsibilities
+with local hosts and instructors at Self-Organised workshops taking on administrative responsibilities
 normally handled by Carpentry staff.  
 
 Instructors (both new and experienced) and workshop hosts
 often have questions about their roles in workshops logistics,
 especially with how their responsibilities differ
-between self-organized and centrally-organized workshops.
+between Self-Organised and centrally-organized workshops.
 To help clarify the roles played by the different participants,
 and the differences between self- and centrally-organized workshops,
 we've put together some resources
@@ -28,13 +28,13 @@ to guide participants through the workshop organizational process.
 
 These resources are available on Data Carpentry's
 "[Host a Workshop]({{site.dc_url}}/workshops-host/)"
-and "[Self-organized Workshops]({{site.dc_url}}/self-organized-workshops/)" pages
+and "[Self-Organised Workshops]({{site.dc_url}}/self-organized-workshops/)" pages
 and include:  
 
 - Checklists for:  
     - [instructors]({{site.dc_url}}/instructor-checklist/)  
     - [hosts for centrally-organized workshops]({{site.dc_url}}/host-checklist/)
-    - [hosts/lead instructors for self-organized workshops]({{site.dc_url}}/self-org-lead/) 
+    - [hosts/lead instructors for Self-Organised workshops]({{site.dc_url}}/self-org-lead/) 
     - and [lead instructors for centrally-organized workshops]({{site.dc_url}}/hosted-lead/)  
 - [Email templates]({{site.dc_url}}/email-templates/) for communicating with co-instructors, helpers, and learners  
 - An [accessibility]({{site.dc_url}}/accessibility/) checklist  

--- a/_posts/2016/10/2016-10-19-okstate-debrief.md
+++ b/_posts/2016/10/2016-10-19-okstate-debrief.md
@@ -7,7 +7,7 @@ time: "11:59:30"
 tags: ["Oklahoma State", "Workshops"]
 ---
 
-I recently instructed Git for the third time at a self-organized
+I recently instructed Git for the third time at a Self-Organised
 workshop on the Oklahoma State University main campus. I enjoy
 instructing and helping with the Software Carpentry workshops (and
 hopefully will get to do a Data Carpentry soon) and each workshop is
@@ -106,7 +106,7 @@ decided to go ahead and do a five-hour session for Day One, and then
 do the normal 9am-4pm schedule for Day Two.
 
 **Coordinating:** Because I've coordinated one of our local
-self-organized workshops, I helped a team member who was going to be
+Self-Organised workshops, I helped a team member who was going to be
 more active with the coordination duties get this workshop set
 up. Once he filled out the
 [SWC workshop request form](https://amy.carpentries.org/workshops/swc/request/),

--- a/_posts/2017/07/2017-07-10-NASA-2.md
+++ b/_posts/2017/07/2017-07-10-NASA-2.md
@@ -9,10 +9,10 @@ tags: [ "Debriefs", "Workshops"]
 
  On 8-9 June, 2017, Katie Moore, Deputy Data Management Team Lead for the [NASA CERES](https://ceres.larc.nasa.gov/) Science Team, and
  Ryan Avery, Geoinformatics Fellow with the [NASA DEVELOP National Program](https://develop.larc.nasa.gov/),
- ran a self-organized workshop in Hampton, VA.
+ ran a Self-Organised workshop in Hampton, VA.
 
  On 12-13 June, 2017, Kunal Marwaha, a software engineer with Palantir, Kelly Meehan, Geoinformatics Fellow with NASA DEVELOP, and Ryan ran another
- self-organized workshop in Norton, VA.
+ Self-Organised workshop in Norton, VA.
 
  Both workshops focused on building skills in NASA DEVELOP participants, who work on 10-week feasibility projects
  that demonstrate how to apply NASA Earth observations to environmental concerns to enhance

--- a/_posts/2017/11/2017-11-30-champions-2nd-summary.md
+++ b/_posts/2017/11/2017-11-30-champions-2nd-summary.md
@@ -70,7 +70,7 @@ At the beginning of the call, as an icebreaker activity, we asked them to descri
 
 - [Kiwi foo](http://www.baacamp.org/), an 'unconference' bringing together creatives, government, policy wonks and technologists to think about making a better world.
 - [Bayesian Models in Ecology Workshop at SESYNC](https://www.sesync.org/opportunities/bayesian-modeling-data), a great combination of lecture/theory and working in small groups, with an emphasis on peer learning.
-- [Fosdem](https://www.fosdem.org), the Free and Open Source Developers European Meeting, run by volunteers, with a wide range of topics. While it had a very self-organised vibe, everything pretty much worked.
+- [Fosdem](https://www.fosdem.org), the Free and Open Source Developers European Meeting, run by volunteers, with a wide range of topics. While it had a very Self-Organised vibe, everything pretty much worked.
 - [useR 2017](https://user2017.brussels/), a first time of connecting with the R community in person. Open, welcoming, attendees of diverse backgrounds, amazing food - I learned so much!
 - Midwest Data Librarian Symposium, a form of un-conference, but in a active learning and participating environment.
 - [CODATA-RDA Research Data Science Summer School, Trieste, Italy](http://indico.ictp.it/event/7974/) - Most of the instructors are from the Carpentries and the quality of lessons is great - a variety of tools/skills taught over 2 weeks (from Unix to Machine Learning in R).

--- a/pages/workshops_request.html
+++ b/pages/workshops_request.html
@@ -47,8 +47,8 @@ All instructors are volunteers, but the Host needs to cover their travel expense
 </p>
 
 <p>
-<h4>Self organized workshops</h4>
-Software Carpentry welcomes you to organize and run your own workshop without administrative assistance from our staff.  This means you are already connected with our certified instructors and will work with them on all aspects of workshop organization, including curriculum and lesson planning as well as logistical details such as student registration. In order to use the Software Carpentry name and logo at your event, we only require that you follow our curriculum, have at least one badged instructor teaching and co-organizing your event, and let us know that you're organizing a workshop. There is no fee (mandated or suggested) due to us for running a self-organized workshop.
+<h4>Self-Organised workshops</h4>
+Software Carpentry welcomes you to organize and run your own workshop without administrative assistance from our staff.  This means you are already connected with our certified instructors and will work with them on all aspects of workshop organization, including curriculum and lesson planning as well as logistical details such as student registration. In order to use the Software Carpentry name and logo at your event, we only require that you follow our curriculum, have at least one badged instructor teaching and co-organizing your event, and let us know that you're organizing a workshop. There is no fee (mandated or suggested) due to us for running a Self-Organised workshop.
 </p>
 
 <p>


### PR DESCRIPTION
Per guidance from @sheraaronhurt and @kmomar this standardizes the text style as follows:

Self-Organised workshop and Centrally-Organised workshop. Capital letters, separated by hyphen, British spelling.