### PR TITLE
Translate hovering labels of Spanish lessons

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -163,10 +163,10 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
   
   <tr>
     <td id="shell-es">La Terminal de Unix</td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="The Unix Shell"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="La Terminal de Unix Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="Sitio de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="Repositorio de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de La Terminal de Unix"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       Clara Llebot, 
@@ -178,10 +178,10 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 
   <tr>
     <td id="git-es">Control de versiones con Git</td>
-    <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="La Terminal de Unix Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Sitio de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Repositorio de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de Control de versiones con Git"></a></td>
     <td>
        <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
@@ -191,10 +191,10 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 
   <tr>
       <td id="git-es">R para Análisis Científicos Reproducibles</td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="R para Análisis Científicos Reproducibles"></a></td>
-      <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="R para Análisis Científicos Reproducibles"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="R para Análisis Científicos Reproducibles Reference"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="R para Análisis Científicos Reproducibles Instructor Notes"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="Sitio de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="Repositorio de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="Referencias de R para Análisis Científicos"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de R para Análisis Científicos Reproducibles"></a></td>
       <td>
           <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
           Verónica Jiménez, 

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -166,7 +166,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="Sitio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="Repositorio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de La Terminal de Unix"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       Clara Llebot, 
@@ -181,7 +181,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Sitio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Repositorio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de Control de versiones con Git"></a></td>
     <td>
        <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
@@ -194,7 +194,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="Sitio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="Repositorio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="Referencias de R para Análisis Científicos"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de R para Análisis Científicos Reproducibles"></a></td>
       <td>
           <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
           Verónica Jiménez, 

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -166,7 +166,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="Sitio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="Repositorio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de La Terminal de Unix"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       Clara Llebot, 
@@ -181,7 +181,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Sitio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Repositorio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de Control de versiones con Git"></a></td>
     <td>
        <a href="https://carpentries.org/maintainers/#iglpdc">Ivan Gonzalez</a>,
       <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
@@ -194,7 +194,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="Sitio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="Repositorio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="Referencias de R para Análisis Científicos"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructores de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para Instructoras/es de R para Análisis Científicos Reproducibles"></a></td>
       <td>
           <a href="https://carpentries.org/maintainers/#raynamharris">Rayna Harris</a>,
           Verónica Jiménez, 
@@ -276,4 +276,3 @@ The Carpentries also shares <a href="https://carpentries.org/community-lessons/"
 </p>
 
 </p>
-


### PR DESCRIPTION
Translate the hovering labels of the links in the Spanish lessons table.

Fixes #1206 
