### PR TITLE
Translate column titles for Spanish lessons

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -158,7 +158,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <th>Repositorio</th>
     <th>Referencias</th>
     <th>Notas para Instructoras/es</th>
-    <th>Mantenedore(s)</th>
+    <th>Reponsable(s) del mantenimiento</th>
   </tr>
   
   <tr>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -153,12 +153,12 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 <table class="table table-striped" style="width: 100%; max-width: 100%">
 
   <tr>
-    <th>Lesson</th>
-    <th>Site</th>
-    <th>Repository</th>
-    <th>Reference</th>
-    <th>Instructor Notes</th>
-    <th>Maintainer(s)</th>
+    <th>Lección</th>
+    <th>Sitio web</th>
+    <th>Repositorio</th>
+    <th>Referencias</th>
+    <th>Notas para Instructores</th>
+    <th>Mantenedore(s)</th>
   </tr>
   
   <tr>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -157,7 +157,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <th>Sitio web</th>
     <th>Repositorio</th>
     <th>Referencias</th>
-    <th>Notas para Instructores</th>
+    <th>Notas para Instructoras/es</th>
     <th>Mantenedore(s)</th>
   </tr>
   
@@ -276,4 +276,3 @@ The Carpentries also shares <a href="https://carpentries.org/community-lessons/"
 </p>
 
 </p>
-


### PR DESCRIPTION
Translate the column titles for the table that lists all the available Spanish lessons.
