### PR TITLE
Improve Spanish translation on templates availability

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -209,7 +209,15 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 </p>
 
 <p>
-  La <a href="https://github.com/swcarpentry/styles-es" target="_blank" title="Estrategia de lección de español"> la plantilla de lección </a> y la <a href="https: // github.com/Carpentries-ES/workshop-template-es" title="plantilla de taller de español" target=" _ blank "> plantilla de taller </a> están disponibles en español. Si está interesado en participar en nuestra lección de español <a href="mailto:{{site.contact}}">contáctenos</a>.
+  La 
+  <a href="https://github.com/swcarpentry/styles-es" target="_blank" title="Estrategia de lección de español">
+    plantilla de la lección
+  </a> y la
+  <a href="https: // github.com/Carpentries-ES/workshop-template-es" title="plantilla de taller de español" target=" _ blank ">
+    plantilla del taller
+  </a> están disponibles en español.
+  Si estás interesade en participar en nuestra lección en español, 
+  <a href="mailto:{{site.contact}}">contáctanos</a>.
 </p>
 
 


### PR DESCRIPTION
Improve the Spanish translation on the text that points readers to the lesson templates.
Also improve the invitation to contact software-carpentry in case readers want to contribute to the lesson.

These changes were suggested by @imartflo , therefore we share the authorship of this PR.