### PR TITLE
remove outdated membership

### DIFF
--- a/pages/curriculum-advisors.md
+++ b/pages/curriculum-advisors.md
@@ -7,11 +7,6 @@ permalink: "/curriculum-advisors/"
 Curriculum Advisors are part of a team that provides the oversight, 
 vision, and leadership for a particular set of lessons. More information 
 about the role of the Curriculum Advisory Committee can be found in the
-[Carpentries Handbook](http://docs.carpentries.org/topic_folders/lesson_development/lesson_development_roles.html#curriculum-advisory-committee). 
+[Carpentries Handbook](https://docs.carpentries.org/topic_folders/lesson_development/curriculum_advisory_committees.html#). 
 
-The Software Carpentry Curriculum Advisors were announced in [this May 2018 blog post](https://software-carpentry.org/blog/2018/05/swc-cac.html).  The current membership is:
-
-- Brittany Lasseigne [@bnlasse](https://twitter.com/bnlasse)
-- Madicken Munk [@munkium](https://twitter.com/munkium)
-- Byron J. Smith [@ByronJSmith](https://twitter.com/ByronJSmith)
-- David Yakobovitch [@davidyako](https://twitter.com/davidyako)
+The Software Carpentry Curriculum Advisors were announced in [this February 2022 blog post](https://carpentries.org/blog/2022/02/announcing-new-cacs/).  For current membership and contact information, refer to [The Carpentries Curriculum Advisors page](https://carpentries.org/curriculum-advisors/).


### PR DESCRIPTION
Remove old CAC members for SWC and point to https://carpentries.org/curriculum-advisors/