### PR TITLE
fix anchor link position

### DIFF
--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -172,3 +172,16 @@ Use as <p class="person">...</p> or <a href="..." class="person">...</a>
     font-weight: bold;
     font-style: italic;
 }
+
+
+*:target:not([id^='fn:']):not([id^='fnref:']) {
+    &::before {
+        content: " ";
+        width: 0;
+        height: 0;
+
+        display: block;
+        padding-top: 50px;
+        margin-top: -50px;
+    }
+}


### PR DESCRIPTION
Fixes css to add white space around anchor links so they don't get hidden by navbar.
See 
https://github.com/carpentries/carpentries.org/pull/1405


---
