### PR TITLE
Fix links to Instructor Notes in lessons.html

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -62,7 +62,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice" target="_blank" class="icon-browser" title="The Unix Shell Main Site"></a></td>
     <td><a href="{{site.github_url}}/shell-novice" target="_blank" class="icon-github" title="The Unix Shell GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice/reference" target="_blank" class="icon-eye" title="The Unix Shell Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="The Unix Shell Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="The Unix Shell Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes">Gerard Capes</a>, Jacob Deppen, Benson Muite
     </td>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -62,7 +62,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice" target="_blank" class="icon-browser" title="The Unix Shell Main Site"></a></td>
     <td><a href="{{site.github_url}}/shell-novice" target="_blank" class="icon-github" title="The Unix Shell GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice/reference" target="_blank" class="icon-eye" title="The Unix Shell Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice/guide/" target="_blank" class="icon-circle-with-plus" title="The Unix Shell Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="The Unix Shell Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes">Gerard Capes</a>, Jacob Deppen, Benson Muite
     </td>
@@ -73,7 +73,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice" target="_blank" class="icon-browser" title="Version Control with Git Main Site"></a></td>
     <td><a href="{{site.github_url}}/git-novice" target="_blank" class="icon-github" title="Version Control with Git GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice/reference" target="_blank" class="icon-eye" title="Version Control with Git Refernce Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice/guide/" target="_blank" class="icon-circle-with-plus" title="Version Control with Git Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="Version Control with Git Instructor Notes"></a></td>
     <td>
       Scott Gruber,
       <a href="https://carpentries.org/maintainers/#nhejazi">Nima Hejazi</a>,
@@ -87,7 +87,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/python-novice-inflammation" target="_blank" class="icon-browser" title="Programming with Python Main Site"></a></td>
     <td><a href="{{site.github_url}}/python-novice-inflammation" target="_blank" class="icon-github" title="Programming with Python GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/python-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with Python Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/python-novice-inflammation/guide/" target="_blank" class="icon-circle-with-plus" title="Programming with Python Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/python-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with Python Instructor Notes"></a></td>
     <td>
       Indraneel Chakraborty, Toan Phung
     </td>
@@ -98,7 +98,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/python-novice-gapminder" target="_blank" class="icon-browser" title="Plotting and Programming in Python Main Site"></a></td>
       <td><a href="{{site.github_url}}/python-novice-gapminder" target="_blank" class="icon-github" title="Plotting and Programming in Python GitHub Repo"></a></td>
       <td><a href="{{site.github_io_url}}/python-novice-gapminder/reference" target="_blank" class="icon-eye" title="Plotting and Programming in Python Reference Guide"></a></td>
-      <td><a href="{{site.github_io_url}}/python-novice-gapminder/guide/" target="_blank" class="icon-circle-with-plus" title="Plotting and Programming Instructor Notes"></a></td>
+      <td><a href="{{site.github_io_url}}/python-novice-gapminder/instructor/" target="_blank" class="icon-circle-with-plus" title="Plotting and Programming Instructor Notes"></a></td>
       <td>
         <a href="https://carpentries.org/maintainers/#alee">Allen Lee</a>,
           Sourav Singh, Martino Sorbaro, <a href="https://carpentries.org/maintainers/#vahtras">Olav Vahtras</a>
@@ -110,7 +110,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/r-novice-inflammation" target="_blank" class="icon-browser" title="Programming with R Main Site"></a></td>
     <td><a href="{{site.github_url}}/r-novice-inflammation" target="_blank" class="icon-github" title="Programming with R GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with R Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/r-novice-inflammation/guide/" target="_blank" class="icon-circle-with-plus" title="Programming with R Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/r-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with R Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#HaoZeke">Rohit Goswami</a>, Hugo Gruson, Isaac Jennings
     </td>
@@ -121,7 +121,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/r-novice-gapminder" target="_blank" class="icon-browser" title="R for Reproducible Scientific Analysis Main Site"></a></td>
     <td><a href="{{site.github_url}}/r-novice-gapminder" target="_blank" class="icon-github" title="R for Reproducible Scientific Analysis GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-gapminder/reference" target="_blank" class="icon-eye" title="R for Reproducible Scientific Analysis Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/r-novice-gapminder/guide/" target="_blank" class="icon-circle-with-plus" title="R for Reproducible Scientific Analysis Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/r-novice-gapminder/instructor/" target="_blank" class="icon-circle-with-plus" title="R for Reproducible Scientific Analysis Instructor Notes"></a></td>
     <td>
       Matthieu Bruneaux, Sehrish Kanwal, <a href="https://carpentries.org/maintainers/#naupaka">Naupaka Zimmerman</a>
     </td>
@@ -153,7 +153,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="Sitio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="Repositorio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de La Terminal de Unix"></a></td>
     <td>
       Verónica Jiménez, 
       Clara Llebot, 
@@ -166,7 +166,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Sitio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Repositorio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de Control de versiones con Git"></a></td>
     <td>
       Jean-Paul Courneya, Clara Llebot, Mariana Patricia Gomez Nicolas
     </td>
@@ -177,7 +177,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="Sitio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="Repositorio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="Referencias de R para Análisis Científicos"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/guide/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de R para Análisis Científicos Reproducibles"></a></td>
       <td>
         Verónica Jiménez, 
         Heladia Salgado,
@@ -224,7 +224,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/make-novice" target="_blank" class="icon-browser" title="Automation and Make Main Site"></a></td>
     <td><a href="{{site.github_url}}/make-novice" target="_blank" class="icon-github" title="Automation and Make GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/make-novice/reference" target="_blank" class="icon-eye" title="Automation and Make Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/make-novice/guide/" target="_blank" class="icon-circle-with-plus" title="Automation and Make Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/make-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="Automation and Make Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes">Gerard Capes</a>
     </td>
@@ -235,7 +235,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/matlab-novice-inflammation" target="_blank" class="icon-browser" title="Programming with MATLAB Main Site"></a></td>
     <td><a href="{{site.github_url}}/matlab-novice-inflammation" target="_blank" class="icon-github" title="Programming with MATLAB GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with MATLAB Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/guide/" target="_blank" class="icon-circle-with-plus" title="Programming with MATLAB Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with MATLAB Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes"></a>
     </td>
@@ -246,7 +246,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/sql-novice-survey" target="_blank" class="icon-browser" title="Using Databases and SQL Main Site"></a></td>
     <td><a href="{{site.github_url}}/sql-novice-survey" target="_blank" class="icon-github" title="Using Databases and SQL GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/sql-novice-survey/reference" target="_blank" class="icon-eye" title="Using Databases and SQL Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/sql-novice-survey/guide/" target="_blank" class="icon-circle-with-plus" title="Using Databases and SQL Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/sql-novice-survey/instructor/" target="_blank" class="icon-circle-with-plus" title="Using Databases and SQL Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#henrykironde">Henry Senyondo</a>
     </td>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -73,7 +73,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice" target="_blank" class="icon-browser" title="Version Control with Git Main Site"></a></td>
     <td><a href="{{site.github_url}}/git-novice" target="_blank" class="icon-github" title="Version Control with Git GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice/reference" target="_blank" class="icon-eye" title="Version Control with Git Refernce Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="Version Control with Git Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Version Control with Git Instructor Notes"></a></td>
     <td>
       Scott Gruber,
       <a href="https://carpentries.org/maintainers/#nhejazi">Nima Hejazi</a>,
@@ -87,7 +87,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/python-novice-inflammation" target="_blank" class="icon-browser" title="Programming with Python Main Site"></a></td>
     <td><a href="{{site.github_url}}/python-novice-inflammation" target="_blank" class="icon-github" title="Programming with Python GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/python-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with Python Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/python-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with Python Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/python-novice-inflammation/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Programming with Python Instructor Notes"></a></td>
     <td>
       Indraneel Chakraborty, Toan Phung
     </td>
@@ -98,7 +98,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/python-novice-gapminder" target="_blank" class="icon-browser" title="Plotting and Programming in Python Main Site"></a></td>
       <td><a href="{{site.github_url}}/python-novice-gapminder" target="_blank" class="icon-github" title="Plotting and Programming in Python GitHub Repo"></a></td>
       <td><a href="{{site.github_io_url}}/python-novice-gapminder/reference" target="_blank" class="icon-eye" title="Plotting and Programming in Python Reference Guide"></a></td>
-      <td><a href="{{site.github_io_url}}/python-novice-gapminder/instructor/" target="_blank" class="icon-circle-with-plus" title="Plotting and Programming Instructor Notes"></a></td>
+      <td><a href="{{site.github_io_url}}/python-novice-gapminder/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Plotting and Programming Instructor Notes"></a></td>
       <td>
         <a href="https://carpentries.org/maintainers/#alee">Allen Lee</a>,
           Sourav Singh, Martino Sorbaro, <a href="https://carpentries.org/maintainers/#vahtras">Olav Vahtras</a>
@@ -110,7 +110,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/r-novice-inflammation" target="_blank" class="icon-browser" title="Programming with R Main Site"></a></td>
     <td><a href="{{site.github_url}}/r-novice-inflammation" target="_blank" class="icon-github" title="Programming with R GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with R Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/r-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with R Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/r-novice-inflammation/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Programming with R Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#HaoZeke">Rohit Goswami</a>, Hugo Gruson, Isaac Jennings
     </td>
@@ -121,7 +121,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/r-novice-gapminder" target="_blank" class="icon-browser" title="R for Reproducible Scientific Analysis Main Site"></a></td>
     <td><a href="{{site.github_url}}/r-novice-gapminder" target="_blank" class="icon-github" title="R for Reproducible Scientific Analysis GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/r-novice-gapminder/reference" target="_blank" class="icon-eye" title="R for Reproducible Scientific Analysis Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/r-novice-gapminder/instructor/" target="_blank" class="icon-circle-with-plus" title="R for Reproducible Scientific Analysis Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/r-novice-gapminder/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="R for Reproducible Scientific Analysis Instructor Notes"></a></td>
     <td>
       Matthieu Bruneaux, Sehrish Kanwal, <a href="https://carpentries.org/maintainers/#naupaka">Naupaka Zimmerman</a>
     </td>
@@ -153,7 +153,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/shell-novice-es" target="_blank" class="icon-browser" title="Sitio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_url}}/shell-novice-es" target="_blank" class="icon-github" title="Repositorio de La Terminal de Unix"></a></td>
     <td><a href="{{site.github_io_url}}/shell-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de La Terminal de Unix"></a></td>
-    <td><a href="{{site.github_io_url}}/shell-novice-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de La Terminal de Unix"></a></td>
+    <td><a href="{{site.github_io_url}}/shell-novice-es/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de La Terminal de Unix"></a></td>
     <td>
       Verónica Jiménez, 
       Clara Llebot, 
@@ -166,7 +166,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice-es" target="_blank" class="icon-browser" title="Sitio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_url}}/git-novice-es" target="_blank" class="icon-github" title="Repositorio de Control de versiones con Git"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice-es/reference" target="_blank" class="icon-eye" title="Referencias de Control de versiones con Git"></a></td>
-    <td><a href="{{site.github_io_url}}/git-novice-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de Control de versiones con Git"></a></td>
+    <td><a href="{{site.github_io_url}}/git-novice-es/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de Control de versiones con Git"></a></td>
     <td>
       Jean-Paul Courneya, Clara Llebot, Mariana Patricia Gomez Nicolas
     </td>
@@ -177,7 +177,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es" target="_blank" class="icon-browser" title="Sitio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_url}}/r-novice-gapminder-es" target="_blank" class="icon-github" title="Repositorio de R para Análisis Científicos Reproducibles"></a></td>
       <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/reference" target="_blank" class="icon-eye" title="Referencias de R para Análisis Científicos"></a></td>
-      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/instructor/" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de R para Análisis Científicos Reproducibles"></a></td>
+      <td><a href="{{site.github_io_url}}/r-novice-gapminder-es/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Notas para las personas instructoras de R para Análisis Científicos Reproducibles"></a></td>
       <td>
         Verónica Jiménez, 
         Heladia Salgado,
@@ -224,7 +224,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/make-novice" target="_blank" class="icon-browser" title="Automation and Make Main Site"></a></td>
     <td><a href="{{site.github_url}}/make-novice" target="_blank" class="icon-github" title="Automation and Make GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/make-novice/reference" target="_blank" class="icon-eye" title="Automation and Make Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/make-novice/instructor/" target="_blank" class="icon-circle-with-plus" title="Automation and Make Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/make-novice/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Automation and Make Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes">Gerard Capes</a>
     </td>
@@ -235,7 +235,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/matlab-novice-inflammation" target="_blank" class="icon-browser" title="Programming with MATLAB Main Site"></a></td>
     <td><a href="{{site.github_url}}/matlab-novice-inflammation" target="_blank" class="icon-github" title="Programming with MATLAB GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/reference" target="_blank" class="icon-eye" title="Programming with MATLAB Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/instructor/" target="_blank" class="icon-circle-with-plus" title="Programming with MATLAB Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/matlab-novice-inflammation/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Programming with MATLAB Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#gcapes"></a>
     </td>
@@ -246,7 +246,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/sql-novice-survey" target="_blank" class="icon-browser" title="Using Databases and SQL Main Site"></a></td>
     <td><a href="{{site.github_url}}/sql-novice-survey" target="_blank" class="icon-github" title="Using Databases and SQL GitHub Repo"></a></td>
     <td><a href="{{site.github_io_url}}/sql-novice-survey/reference" target="_blank" class="icon-eye" title="Using Databases and SQL Reference Guide"></a></td>
-    <td><a href="{{site.github_io_url}}/sql-novice-survey/instructor/" target="_blank" class="icon-circle-with-plus" title="Using Databases and SQL Instructor Notes"></a></td>
+    <td><a href="{{site.github_io_url}}/sql-novice-survey/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Using Databases and SQL Instructor Notes"></a></td>
     <td>
       <a href="https://carpentries.org/maintainers/#henrykironde">Henry Senyondo</a>
     </td>


### PR DESCRIPTION
Fixing links to instructor notes for all lessons by changing "guide" to "instructor" ex:

https://swcarpentry.github.io/shell-novice/guide/ ->
https://swcarpentry.github.io/shell-novice/instructor/ 

This is part of my instructor checkout process.