### PR TITLE
remove links to "lesson template"

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -24,20 +24,20 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 
 <div class="row">
   <div class="medium-4 columns">
-    <h4>Curriculum</h4>
+    <h4 id="curriculum">Curriculum</h4>
     <p>
       Our lessons are developed collaboratively on <a href="{{site.github_url}}">GitHub</a>. You can check the status of each lesson on <a href="{{site.baseurl}}/lessons/dashboard/">our dashboard</a>, or look at <a href="{{site.baseurl}}/lessons/previous">older releases</a>.  Our <a href="{{site.baseurl}}/curriculum-advisors">Curriculum Advisors</a> are part of a team that provides the oversight, vision, and leadership towards lesson development.
     </p>
   </div>
   <div class="medium-4 columns">
-    <h4>Availability</h4>
+    <h4 id="availability">Availability</h4>
     <p>
       All of our lessons are freely available under the <a href="{{site.baseurl}}/license/">Creative Commons - Attribution License</a>.  You may re-use and re-mix the material in any way you wish,
       without asking permission, provided you cite us as the original source (e.g., provide a link back to this website).
     </p>
   </div>
   <div class="medium-4 columns">
-    <h4>Contributing</h4>
+    <h4 id="contributing">Contributing</h4>
     <p>
       If you have questions about contributing to our lessons, visit each lesson's GitHub repo to submit an issue or to get the link to join that lesson's Maintainers' discussion on Slack. For general information on how to contribute to our lessons, see our <a href="https://github.com/swcarpentry/git-novice/blob/main/CONTRIBUTING.md">contributors guide</a>.  To learn more about how our lessons are structured, and why, please see <a href="{{site.carp_gh_io_url}}/workbench">the Workbench documentation and resources page</a>. 
      </p>
@@ -45,7 +45,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 </div>
 
 
-<h2>Our Core Lessons in English</h2>
+<h2 id="en">Our Core Lessons in English</h2>
 
 <table class="table table-striped" style="width: 100%; max-width: 100%">
   <tr>
@@ -129,13 +129,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 
 </table>
 
-
-<p>
-<a href="{{site.github_url}}/styles">The lesson template</a> (used to build each lesson page) and the <a href="{{site.github_url}}/workshop-template">workshop template </a> (used to build each scheduled workshop's website) are available on GitHub. 
-</p>
-
-
-<h2>Our Core Lessons in Spanish</h2>
+<h2 id="es">Our Core Lessons in Spanish</h2>
 
 <table class="table table-striped" style="width: 100%; max-width: 100%">
 
@@ -185,11 +179,6 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
       </td>
   </tr>
 </table>
-
-<p>
-  The <a href="https://github.com/swcarpentry/styles-es" target="_blank" title="Spanish lesson template">lesson template</a> and the <a href="https://github.com/Carpentries-ES/workshop-template-es" title="Spanish workshop tempalte" target="_blank">workshop template</a> are available in Spanish. If you are interested in getting involved with our Spanish lessons <a href="mailto:{{site.contact}}">contact us</a>.
-</p>
-
 <p>
   La 
   <a href="https://github.com/swcarpentry/styles-es" target="_blank" title="Estrategia de lección de español">
@@ -203,7 +192,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
 </p>
 
 
-<h2>Additional Lessons</h2>
+<h2 id="additional-lessons">Additional Lessons</h2>
 
 <p>
   These lessons are not part of Software Carpentry core lessons but can be offered as supplementary lessons. Please <a href="mailto:{{site.contact}}">contact us</a> for more information.


### PR DESCRIPTION
 - remove extraneous links to lesson template and workshop
   template as they were not needed in context
 - add heading ids for navigation

This will fix #1247 