### PR TITLE
Change SWC Twitter link to Mastodon link

### DIFF
--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -1,51 +1,19 @@
 - name: GitHub
   url: http://github.com/swcarpentry
-  class: icon-github
+  class: fab fa-github
   title: "Source on GitHub"
 
-- name: Twitter
-  url: http://twitter.com/swcarpentry
-  class: icon-twitter
-  title: "Software Carpentry on Twitter"
+- name: Mastodon
+  url: https://hachyderm.io/@thecarpentries
+  class: fab fa-mastodon
+  title: "The Carpentries on Mastodon"
 
 - name: YouTube
   url: https://www.youtube.com/user/softwarecarpentry
-  class: icon-youtube
+  class: fab fa-youtube
   title: "Software Carpentry Videos"
 
 - name: LinkedIn
   url: https://www.linkedin.com/groups/8279689
-  class: icon-linkedin
+  class: fab fa-linkedin-in
   title: "LinkedIn Instructors Group"
-
-#------------------------------------------------------------
-
-# - name: Facebook
-#   url: http://www.facebook.com/phlow.media
-#   class: icon-facebook
-#   title: "Lass uns Freunde sein!"
-
-# - name: Soundcloud
-#   url: http://soundcloud.com/phlow
-#   class: icon-soundcloud
-#   title: "Sounds und Downloads und mehr"
-
-# - name: Instagram
-#   url: http://instagram.com/phlowmedia
-#   class: icon-instagram
-#   title: "Bilder und Impressionen mit und ohne Filter..."
-
-# - name: Pinterest
-#   url: http://www.pinterest.com/phlowmedia/
-#   class: icon-pinterest
-#   title: "Bilder, Fotos, Illustrationen, Grafiken sammeln..."
-
-# - name: Mixcloud
-#   url: http://www.mixcloud.com/phlow/
-#   class: icon-cloud
-#   title: "Mixe, was sonst?"
-
-# - name: Xing
-#   url: https://www.xing.com/profile/Moritzmo_Sauer
-#   class: icon-xing
-#   title: Xing Profil

--- a/_includes/head
+++ b/_includes/head
@@ -14,6 +14,9 @@
     });
   </script>
 
+  <!-- Adding Font Awesome -->
+  <script src="https://kit.fontawesome.com/3a6fac633d.js" crossorigin="anonymous"></script>
+
   <noscript>
     <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic|Volkhov' rel='stylesheet' type='text/css' />
   </noscript>

--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -313,8 +313,9 @@ h3.masthead {
 
     #footer .social-icons li a {
         font-size: rem-calc(23);
+        padding: rem-calc(7); // font-size + 2*padding = width
         display: block;
-        width: 36px;
+        width: rem-calc(37);
         border-radius: 50%;
         color: $footer-bg;
         background: $footer-color;

--- a/pages/about.html
+++ b/pages/about.html
@@ -52,7 +52,7 @@ excerpt: Software Carpentry teaches researchers foundational computing skills
       You can <a href="mailto:team@carpentries.org">send us email</a>,
       <a href="https://carpentries.org/newsletter/">sign up for our newsletter</a>,
       <a href="https://carpentries.org/blog/">read our blog</a>,
-      follow <a href="https://twitter.com/swcarpentry">Software Carpentry</a> and <a href="https://twitter.com/thecarpentries">The Carpentries</a> on Twitter,
+      follow <a href="https://hachyderm.io/@thecarpentries">The Carpentries</a> on Mastodon,
       or browse and raise issues against <a href="https://github.com/swcarpentry">our repositories on GitHub</a>.
     </p>
   </div>


### PR DESCRIPTION
Removes the SWC Twitter from the website, and replaces it with our unified Mastodon link.

I had to switch the social icons to FontAwesome to get the Mastodon icon, and tweak the CSS accordingly.