### PR TITLE
Fix contrast issues in navigation

### DIFF
--- a/_sass/_01_settings_colors.scss
+++ b/_sass/_01_settings_colors.scss
@@ -82,9 +82,10 @@ $topbar-bg-color: #fff;
 $topbar-dropdown-toggle-color: $swc-blue;
 
 $topbar-link-color: #000;
-$topbar-link-color-hover: #000;
-$topbar-link-color-active: #000;
-$topbar-link-color-active-hover: #000;
+$topbar-link-color-hover: #fff;
+$topbar-link-color-active: #fff;
+$topbar-link-color-active-hover: #fff;
+$topbar-expanded-link-color: #fff;
 
 $topbar-dropdown-label-color: $swc-blue-light;
 $topbar-dropdown-link-bg-hover: $swc-blue-med;
@@ -94,7 +95,7 @@ $topbar-link-bg-hover: $swc-blue-med;
 $topbar-link-bg-active-hover: $swc-blue-light;
 
 $topbar-dropdown-bg: $swc-blue-med; // Background Mobile Navigation
-$topbar-dropdown-link-color: #000;
+$topbar-dropdown-link-color: #fff;
 $topbar-dropdown-link-bg: $swc-blue-light;
 
 $topbar-menu-link-color-toggled: $swc-blue;

--- a/_sass/foundation-components/_top-bar.scss
+++ b/_sass/foundation-components/_top-bar.scss
@@ -284,6 +284,10 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
             }
           }
         }
+
+        .top-bar-section li > a {
+          color: $topbar-expanded-link-color;
+        }
       }
     }
 
@@ -426,7 +430,7 @@ $topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text 
             margin-top: 0;
             font-size: $topbar-back-link-size;
             a {
-              color: $topbar-link-color;
+              color: $topbar-expanded-link-color;
               // line-height: ($topbar-height / 2);
               display: block;
               &:hover { background:none; }


### PR DESCRIPTION
Fixes #1255 by changing text color of nav links to white when the background is blue (e.g. when hovering or in dropdowns)

Tested in both wide (menu bar) and narrow (hamburger menu) views.