### PR TITLE
use https links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Software Carpentry Website
 
-This is the repository for the new [Software Carpentry website](http://software-carpentry.org).
+This is the repository for the new [Software Carpentry website](https://software-carpentry.org).
 Please submit additions and fixes as pull requests to [our GitHub repository](https://github.com/swcarpentry/website).
 
 *   [Setup](#setup)
@@ -21,12 +21,12 @@ for links to their repositories.
 > and we welcome contributions of all kinds.
 > By contributing,
 > you are agreeing that Software Carpentry may redistribute your work
-> under [these licenses](http://software-carpentry.org/license/),
-> and to abide by [our code of conduct](http://software-carpentry.org/conduct/).
+> under [these licenses](https://software-carpentry.org/license/),
+> and to abide by [our code of conduct](https://software-carpentry.org/conduct/).
 
 ## Setup <a name="setup"></a>
 
-The website uses [Jekyll](http://jekyllrb.com/), a static website generator written in Ruby.
+The website uses [Jekyll](https://jekyllrb.com/), a static website generator written in Ruby.
 You need to have Version 2.7.1 or higher of Ruby and the package manager Bundler (The package manager is used to make sure you use exactly the same versions of software as GitHub Pages).
 Bundler can be installed with `$ gem install bundler`.
 If you are on Linux, you will need to install the Ruby header files (e.g., `$ sudo apt-get install ruby-dev` on Debian/Ubuntu).
@@ -41,7 +41,7 @@ $ bundle install
 to install Jekyll and the software it depends on.
 You may consult [Using Jekyll with Pages](https://help.github.com/articles/using-jekyll-with-pages/) for further instructions.
 
-You will also need [Python 3](http://python.org/) with
+You will also need [Python 3](https://python.org/) with
 [PyYAML](https://pypi.python.org/pypi/PyYAML/) available in order to
 re-generate the [data files](#details) the site depends on.
 
@@ -69,7 +69,7 @@ YYYY is the 4-digit year of the post, MM the 2-digit month, and DD the 2-digit d
 `some-title` can be any hyphenated string of words that do not include special characters such as quotes.
 Please do *not* use underscores or periods in the names.
 When published,
-your blog post will appear as `http://software-carpentry.org/blog/YYYY/MM/some-title.html`.
+your blog post will appear as `https://software-carpentry.org/blog/YYYY/MM/some-title.html`.
 
 The YAML header of a blog post must look like this:
 
@@ -156,4 +156,4 @@ and every 6 hours, the GitHub Action does the following:
 
 ### Previewing the live site
 
-Once changes to the site are merged, they can take several hours to go live.  In the meantime, changes can be [previewed here](http://software-carpentry.org.s3-website-us-east-1.amazonaws.com/). 
+Once changes to the site are merged, they can take several hours to go live.  In the meantime, changes can be [previewed here](https://software-carpentry.org.s3-website-us-east-1.amazonaws.com/). 

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ description: "Software Carpentry is a volunteer project dedicated to teaching ba
 author: gvwilson
 
 # This URL identifies the domain.
-url: 'http://software-carpentry.org'
+url: 'https://software-carpentry.org'
 
 # This URL is the root of the site below the domain.
 baseurl: ''
@@ -53,26 +53,26 @@ filesurl: '/files'
 amy_url         : "https://amy.carpentries.org/workshops"
 board_inquiries : "board-inquiries@software-carpentry.org"
 contact         : "team@carpentries.org"
-dc_url          : "http://datacarpentry.org"
+dc_url          : "https://datacarpentry.org"
 lc_url          : "https://librarycarpentry.org"
 facebook_url    : "https://www.facebook.com/SoftwareCarpentry"
 github_url      : "https://github.com/swcarpentry"
-github_io_url   : "http://swcarpentry.github.io"
+github_io_url   : "https://swcarpentry.github.io"
 paypal_url      : "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MYSDWRR8HWFR6"
 linkedin_url    : "https://www.linkedin.com/grp/home?gid=8279689"
-rss_url         : "http://software-carpentry.org/feed.xml"
+rss_url         : "https://software-carpentry.org/feed.xml"
 twitter_name    : "@swcarpentry"
 twitter_url     : "https://twitter.com/swcarpentry"
-slack_signup_url: "http://slack-invite.carpentries.org/"
-msl_url         : "http://mozillascience.org"
-store_url       : "http://www.cafepress.com/swcarpentry"
-pad_url         : "http://pad.software-carpentry.org"
-mailing_lists   : "http://lists.software-carpentry.org"
+slack_signup_url: "https://slack-invite.carpentries.org/"
+msl_url         : "https://wiki.mozilla.org/ScienceLab"
+store_url       : "https://www.cafepress.com/swcarpentry"
+pad_url         : "https://pad.software-carpentry.org"
+mailing_lists   : "https://carpentries.topicbox.com"
 flag_size       : 16
 v4_url          : "https://v4.software-carpentry.org"
-releases_io_url : "http://swcarpentry.github.io/swc-releases"
-training_url    : "http://carpentries.github.io/instructor-training"
-carp_gh_io_url  : "http://carpentries.github.io"
+releases_io_url : "https://swcarpentry.github.io/swc-releases"
+training_url    : "https://carpentries.github.io/instructor-training"
+carp_gh_io_url  : "https://carpentries.github.io"
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages


### PR DESCRIPTION
Update the links in the config and README to use https.

On the home page there are currently mixed content warnings in the browser console, which are caused by the `url` in the config file not using https, causing the assets in the workshop feed to be loaded using http. I also went ahead and updated some others for consistency, and fixed a couple of the links that were broken (`msl_url` and `mailing_lists`).
