### PR TITLE
redirect Curriculum Advisors page to Carpentries website page

### DIFF
--- a/pages/curriculum-advisors.md
+++ b/pages/curriculum-advisors.md
@@ -2,11 +2,8 @@
 layout: page-fullwidth
 title: "Curriculum Advisors"
 permalink: "/curriculum-advisors/"
+redirect_to:
+  - https://carpentries.org/curriculum-advisors/
 ---
 
-Curriculum Advisors are part of a team that provides the oversight, 
-vision, and leadership for a particular set of lessons. More information 
-about the role of the Curriculum Advisory Committee can be found in the
-[Carpentries Handbook](https://docs.carpentries.org/topic_folders/lesson_development/curriculum_advisory_committees.html#). 
 
-The Software Carpentry Curriculum Advisors were announced in [this February 2022 blog post](https://carpentries.org/blog/2022/02/announcing-new-cacs/).  For current membership and contact information, refer to [The Carpentries Curriculum Advisors page](https://carpentries.org/curriculum-advisors/).


### PR DESCRIPTION
Fixes #1263 