### PR TITLE
remove inactive Maintainers

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -75,10 +75,7 @@ excerpt: All our lessons are created collaboratively and can be freely re-used, 
     <td><a href="{{site.github_io_url}}/git-novice/reference" target="_blank" class="icon-eye" title="Version Control with Git Refernce Guide"></a></td>
     <td><a href="{{site.github_io_url}}/git-novice/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Version Control with Git Instructor Notes"></a></td>
     <td>
-      Scott Gruber,
-      <a href="https://carpentries.org/maintainers/#nhejazi">Nima Hejazi</a>,
       <a href="https://carpentries.org/maintainers/#kekoziar">Katherine Koziar</a>, 
-      Madicken Munk,
       Martino Sorbaro
     </td>
   </tr>


### PR DESCRIPTION
Remove Maintainers who did not respond to Workbench transition updates as per https://github.com/swcarpentry/git-novice/issues/915. Fixes https://github.com/swcarpentry/git-novice/issues/975.