### PR TITLE
specify bundler version

### DIFF
--- a/.github/workflows/build-website.yaml
+++ b/.github/workflows/build-website.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install bundler yaml-lint
+          gem install bundler:2.4.22 yaml-lint
 
       - name: Set up caching for Bundler
         uses: actions/cache@v2

--- a/.github/workflows/check-pull-requests.yml
+++ b/.github/workflows/check-pull-requests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install bundler yaml-lint
+          gem install bundler:2.4.22 yaml-lint
 
       - name: Set up caching for Bundler
         uses: actions/cache@v2


### PR DESCRIPTION
The website build workflow has been failing for the last few days, as we are pinned to an older version of Ruby. This patch should get them running again. I do not know if it would be better to try to use a newer version of Ruby.