### PR TITLE
pin jekyll and gh-pages versions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 group :jekyll_plugins do
   gem 'github-pages', '206'
   gem 'jekyll-redirect-from'
-  gem 'jekyll-get-json', "~> 1.0.0",
+  gem 'jekyll-get-json', "~> 1.0.0"
   gem 'jekyll', '3.8.7'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 group :jekyll_plugins do
-  gem 'github-pages'
+  gem 'github-pages', '206'
   gem 'jekyll-redirect-from'
-  gem 'jekyll-get-json', "~> 1.0.0"
+  gem 'jekyll-get-json', "~> 1.0.0",
+  gem 'jekyll', '3.8.7'
 end


### PR DESCRIPTION
Following [this build error](https://github.com/swcarpentry/website/actions/runs/7819139798/job/21330951204#step:14:15) and [this PR to the carpentries.org repo](https://github.com/carpentries/carpentries.org/pull/1779) this PR pins jekyll and gh pages versions to previous working versions.