### PR TITLE
feat: edits to CONTRIBUTING.md and Software Carpentry home page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-[Software Carpentry][swc-site] and [Data Carpentry][dc-site] are open source projects,
+[Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site] are open source projects,
 and we welcome contributions of all kinds:
 blog posts,
 fixes to existing material,
@@ -11,9 +11,8 @@ and reviews of proposed changes are all welcome.
 
 By contributing,
 you agree that we may redistribute your work under [our license](LICENSE.md).
-Everyone involved in [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
+Everyone involved in [Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site]
 agrees to abide by our [code of conduct][conduct].
-
 
 ## How to Contribute a Fix or Suggested Change
 
@@ -107,7 +106,7 @@ Separate the header block from the post proper by a new line.
   
 ## Other Resources
 
-General discussion of [Software Carpentry][swc-site] and [Data Carpentry][dc-site]
+General discussion of [Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site]
 happens on the [discussion mailing list][discuss-list],
 which everyone is welcome to join.
 You can also [reach us by email][contact].
@@ -123,6 +122,7 @@ You can also [reach us by email][contact].
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/swcarpentry/website/issues/
+[lc-site]: https://librarycarpentry.org/
 [repo]: https://github.com/swcarpentry/website/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ filesurl: '/files'
 # FIXME: eliminate some of these (duplicate social media information)
 amy_url         : "https://amy.carpentries.org/workshops"
 board_inquiries : "board-inquiries@software-carpentry.org"
+carpentries_url : "https://carpentries.org"
 contact         : "team@carpentries.org"
 dc_url          : "https://datacarpentry.org"
 lc_url          : "https://librarycarpentry.org"

--- a/pages/index.html
+++ b/pages/index.html
@@ -14,7 +14,7 @@ excerpt: Teaching researchers the foundational computing skills they need to get
   Having started in 1998,
   Software Carpentry is now a lesson program within <a href="{{site.carpentries_url}}">The Carpentries</a>.
   Its focus is on the the computing skills researchers need to get more done in less time and with less pain,
-  and its <a href="{{site.carpentries_url}}/instructors/">volunteer instructors</a>
+  and its <a href="{{site.carpentries_url}}/instructors/">volunteer Instructors</a>
   have run thousands of events for almost one hundred thousand people since 2012.
   <em>Our target audience is researchers who have some prior programming experience<em>
   but who are largely self-taught

--- a/pages/index.html
+++ b/pages/index.html
@@ -4,208 +4,37 @@ permalink: /index.html
 excerpt: Teaching researchers the foundational computing skills they need to get more done in less time
 ---
 
-<h2>About Software Carpentry</h2>
+<h2>What is Software Carpentry?</h2>
 <p>
-  Since 1998,
-  Software Carpentry has been teaching researchers
-  the computing skills they need to get more done in less time and with less pain.
-  Our <a href="https://carpentries.org/instructors/">volunteer instructors</a>
-  have run <a href="{{site.baseurl}}/workshops/past/">hundreds of events</a>
-  for more than 34,000 researchers since 2012.
-  All of our <a href="{{site.baseurl}}/lessons/">lesson materials</a> are freely reusable
-  under the <a href="{{site.baseurl}}/license/#cc-by">Creative Commons - Attribution license</a>.
+  Software Carpentry develops and teaches workshops on the fundamental programming skills needed to conduct research.
+  Our mission is to provide researchers high-quality, domain-specific training
+  covering all aspects of research software engineering.
 </p>
 <p>
-  The <a href="{{site.baseurl}}/scf/">Software Carpentry Foundation</a>
-  and its sibling lesson project, <a href="{{site.dc_url}}">Data Carpentry</a>,
-  have merged to become The Carpentries, a fiscally sponsored project of <a href="http://communityin.org">Community Initiatives</a>,
-  a 501(c)3 non-profit incorporated in the United States. See the <a href="https://carpentries.org/team/">staff page for The Carpentries</a>.
-</p>
-
-<div class="row">
-
-  <div class="medium-4 columns">
-    <h4>Supporters</h4>
-    <p>
-      Software Carpentry is made possible by the generous support of
-      <a href="https://carpentries.org/members/">our member organisations</a>
-      and by the hard work of <a href="https://carpentries.org/community">our volunteers</a>.
-      We offer <a href="https://carpentries.org/membership/">several levels of institutional engagement</a>. We provide 
-      <a href="https://carpentries.org/community">many 
-        ways</a> people can engage with our community.
-    </p>
-  </div>
-
-  <div class="medium-4 columns">
-    <h4>Workshops</h4>
-    <p>
-      You can <a href="{{site.baseurl}}/workshops/request/">host a workshop</a>
-      or <a href="{{site.baseurl}}/workshops/">attend one</a> that someone else is hosting.
-      Our <a href="https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html">code of conduct</a>
-      and <a href="https://docs.carpentries.org/topic_folders/hosts_instructors/index.html">operations guides</a>
-      describe how our workshops are organised and run.
-    </p>
-  </div>
-
-  <div class="medium-4 columns">
-    <h4>Conversations</h4>
-    <p>
-      You can <a href="mailto:team@carpentries.org">send us email</a>,
-      <a href="https://carpentries.org/newsletter/">sign up for our newsletter</a>,
-      <a href="https://carpentries.org/blog/">read our blog</a>,
-      follow <a href="https://hachyderm.io/@thecarpentries">The Carpentries</a> on Mastodon,
-      or browse and raise issues against <a href="https://github.com/swcarpentry">our repositories on GitHub</a>.
-    </p>
-  </div>
-
-</div> <!-- /row -->
-
-<div class="row">
-
-  <div class="medium-4 columns">
-    <h4>Make Things</h4>
-    <p>
-      As an open source project,
-      we rely on volunteers to
-      <a href="{{site.baseurl}}/lessons/">create our lessons</a>.
-    </p>
-  </div>
-
-  <div class="medium-4 columns">
-    <h4>Read Things</h4>
-    <p>
-      <a href="http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1001745">Best Practices in Scientific Computing</a>
-      and
-      <a href="http://f1000research.com/articles/3-62/v2">Software Carpentry: Lessons Learned</a>
-      summarize what we've learned.
-    </p>
-  </div>
-
-</div> <!-- /row -->
-
-
-<h2>In the Beginning...</h2>
-<p>
-  In 1995-96,
-  Greg Wilson organized a series of articles in <em>IEEE Computational Science &amp; Engineering</em> titled,
-  "What Should Computer Scientists Teach to Physical Scientists and Engineers?"
-  These articles grew out of his frustration working with scientists
-  who wanted to parallelize complex programs
-  but didn't know what version control was,
-  how to write a unit test,
-  or even why they should break their programs down into functions.
+  Having started in 1998,
+  Software Carpentry is now a lesson program within <a href="{{site.carpentries_url}}">The Carpentries</a>.
+  Its focus is on the the computing skills researchers need to get more done in less time and with less pain,
+  and its <a href="{{site.carpentries_url}}/instructors/">volunteer instructors</a>
+  have run thousands of events for almost one hundred thousand people since 2012.
+  <em>Our target audience is researchers who have some prior programming experience<em>
+  but who are largely self-taught
+  and are ready to move from writing short programs for personal use
+  to collaborating with others on larger, reusable pieces of software.
 </p>
 <p>
-  In response,
-  John Reynders (then director of the Advanced Computing Laboratory at Los Alamos National Laboratory)
-  invited Wilson and Brent Gorda (now at Intel) to teach a week-long course to LANL staff.
-  The course ran for the first time in July 1998,
-  and was repeated nine times over the next four years.
-  It eventually wound down as the principals moved on to other projects,
-  but taught us two valuable lessons:
-</p>
-<ol>
-  <li>
-    <p>
-      There is tremendous pent-up demand for training in basic skills.
-    </p>
-  </li>
-  <li>
-    <p>
-      Textbook software engineering is not the right thing to teach most scientists.
-    </p>
-  </li>
-</ol>
-<h2>Going Open</h2>
-<p>
-  The Software Carpentry materials were updated and released under a Creative Commons license in 2004-05
-  thanks to support from the Python Software Foundation.
-  They attracted 1000-2000 unique visitors a month,
-  with occasional spikes correlated to courses and mentions in other sites,
-  and were used in a semester-long graduate course offered in 2007-09 at the University of Toronto.
-  Again,
-  we learned some valuable lessons;
-  the most important is that
-  while faculty in science, engineering, and medicine will agree that their students should learn more about computing,
-  they <em>won't</em> agree on what to take out of the current curriculum to make room for it.
-  Until that changes,
-  we have to deliver our lessons "between" standard courses.
-</p>
-<h2>The Video Version</h2>
-<p>
-  Greg Wilson left the University of Toronto in April 2010 to reboot Software Carpentry
-  with support from nine sponsor organizations.
-  Over the next year,
-  he recorded 120 short video lessons and ran half a dozen week-long classes for his backers.
+  We teach hands-on workshops in the Unix shell, verison control, and programming in languages such as Python and R
+  to increase computational competence and improve research efficiency.
+  Our evidence-based pedagogy,
+  combined with rapid iteration on content,
+  ensures that our lessons are directly connected to real scientific questions
+  and directly relevant to participants' research.
+  We create a friendly environment for learning to empower researchers,
+  and all of our lesson materials are freely reusable under an open license.
 </p>
 <p>
-  This version of Software Carpentry was much more successful than its predecessors,
-  in part because the scientific landscape itself had changed.
-  Open access publishing, citizen science, and dozens of other innovations
-  had convinced scientists that they needed to be able to do more than just crunch numbers.
-  We also made contact with like-minded organizations,
-  particularly <a href="https://thehackerwithin.github.io/">The Hacker Within</a>,
-  who showed us that intensive two-day workshops worked better than week-long classes.
-  Putting this all together led to our current model:
-</p>
-<ul>
-  <li>
-    <p>
-      Curriculum is developed and improved in a public repository
-      using methods borrowed from the open source software community.
-    </p>
-  </li>
-  <li>
-    <p>
-      Instructors volunteer their time,
-      while workshop host sites cover their travel and accommodation costs.
-    </p>
-  </li>
-  <li>
-    <p>
-      Instructors use live coding instead of slides
-      while learners following along on their own machines.
-    </p>
-  </li>
-</ul>
-<h2>Scaling Up</h2>
-<p>
-  In the fall of 2011,
-  Wilson worked with the Mozilla Foundation to prepare a grant to the Sloan Foundation
-  to put Software Carpentry on a more stable financial footing.
-  That grant,
-  awarded in January 2012,
-  and a second one later that year
-  paid for Wilson and some administrative support,
-  which allowed us to increase the number of workshops.
-  In turn,
-  that growth led to us starting a training program
-  to teach instructors the basics of educational psychology and instructional design.
-</p>
-<h2>The Present Day</h2>
-<p>
-  Wilson left Mozilla in July 2014 to help found the Software Carpentry Foundation,
-  an independent non-profit volunteer sponsored by <a href="http://numfocus.org">NumFOCUS</a>.
-  Software Carpentry's governing body is a <a href="{{site.baseurl}}/scf/">Steering Committee</a>,
-  which is elected from and by its <a href="{{site.baseurl}}/scf/members/">members</a>
-  and assisted by an Advisory Board made up of representatives from partner organizations.
-  The Foundation's <a href="{{site.baseurl}}/scf/#committee-2015">first Steering Committee</a>
-  was elected in January 2015,
-  and in October 2015
-  <a href="{{site.baseurl}}/team/#duckles.jonah">Jonah Duckles</a> began work
-  as the Foundation's new Executive Director.
-</p>
-<p>
-In February 2018, Software Carpentry and Data Carpentry merged their projects together
-into a new project, The Carpentries, sponsored by <a href="http://communityin.org">Community Initiatives</a>.
-With this merger, Software Carpentry has combined staff, budget and governance to form the new project.
-The Carpentries continue the work of Software Carpentry and Data Carpentry, realizing that
-the communities of instructors, members and lesson developers are stronger working together. With over 50
-member organizations in 10 countries, The Carpentries seek to build and grow communities of practice around
-computational skills development for researchers.
-</p>
-<p>
+  Workshops like ours cannot teach people everything they need to know about research software engineering,
+  but they drastically reduce the barrier to entry
+  and impart the skills and confidence needed for continued learning and engagement.
   To learn more about our history and the lessons we've learned along the way,
-  please see the paper
-  "<a href="http://f1000research.com/articles/3-62/v2">Software Carpentry: Lessons Learned</a>".
+  please see "<a href="http://f1000research.com/articles/3-62/v2">Software Carpentry: Lessons Learned</a>".
 </p>


### PR DESCRIPTION
1. Add Library Carpentry to CONTRIBUTING.md.
2. Rewrite Software Carpentry home page to remove historical fluff and make wording similar to that used on DC and LC pages.